### PR TITLE
Improved string support for Python 2.x

### DIFF
--- a/src/contracts/library/__init__.py
+++ b/src/contracts/library/__init__.py
@@ -2,7 +2,7 @@ from .suggester import create_suggester
 from .dummy import Any, Never
 from .separate_context import SeparateContext
 from .types_misc import Type, CheckType, Number
-from .strings import String, AnsiString, UnicodeString
+from .strings import *
 from .lists import List
 from .seq import Seq
 from .tuple import Tuple

--- a/src/contracts/library/strings.py
+++ b/src/contracts/library/strings.py
@@ -40,12 +40,16 @@ class StringBase(Contract):
 import sys
 if sys.version_info[0] == 3:  # Python 3
 
+    __all__ = ['String']
+
     class String(StringBase):
         KEYWORDS = ['str', 'string']
         TYPE = str
         DESCRIPTION = "a string"
 
 else:  # Python 2.x
+
+    __all__ = ['String', 'AnsiString', 'UnicodeString']
 
     class String(StringBase):
         KEYWORDS = ['string']


### PR DESCRIPTION
I found that support for string contracts in Python 2.x is lacking because the `string`/`str` keyword matches only `str` type. For applications using Unicode strings, that's not really viable.

So I made some improvements in this regard:
- I added `unicode` keyword that explicitly matches `unicode` strings (only in 2.x)
- I made `str` keyword to match `str` type only (so ANSI strings in 2.x and all/Unicode strings in 3.x)
- I changed `string` to match both `str` and `unicode` in 2.x and just `str` in 3.x

I'm aware that the last change modifies the original meaning of `string` keyword for Python 2.x so that it's more lenient. Existing contract specs using `string` will still allow what they used to allow, of course, but they will now also accept `unicode` strings in addition to `str` ones. So it doesn't break existing usage while (I think) making the keyword more intuitive for Python 2.x developers.

Also, the current meaning of `string` is not really documented anywhere (I had to find it in source, personally) and thus I suppose changing it slightly will not harm any existing usage.
