### PR TITLE
Added support for attribute contracts

### DIFF
--- a/src/contracts/library/__init__.py
+++ b/src/contracts/library/__init__.py
@@ -8,7 +8,7 @@ from .seq import Seq
 from .tuple import Tuple
 from .dicts import Dict
 from .map import Map
-from .objects import Object
+from .attr import Attr 
 from .comparison import CheckOrder
 from .arithmetic import Binary, Unary
 from .compositions import OR, And, composite_contract, or_contract

--- a/src/contracts/library/attr.py
+++ b/src/contracts/library/attr.py
@@ -6,7 +6,7 @@ from pyparsing import (Dict, delimitedList, Group, alphanums,
         Suppress, Literal, Word)
 
 
-class Object(Contract):
+class Attr(Contract):
     def __init__(self, attrs=None, where=None):
         Contract.__init__(self, where)
         self.attrs = attrs
@@ -24,7 +24,7 @@ class Object(Contract):
                     self.attrs[k]._check_contract(context, getattr(value, k))
 
     def __str__(self):
-        s = 'object'
+        s = 'attr'
         if self.attrs is not None:
             for k in self.attrs:
                 s += '(%s:%s),' % (k, self.attrs[k])
@@ -33,7 +33,7 @@ class Object(Contract):
         return s
 
     def __repr__(self):
-        return 'Object(%r)' % self.attrs
+        return 'Attr(%r)' % self.attrs
 
     @staticmethod
     def parse_action(s, loc, tokens):
@@ -41,7 +41,7 @@ class Object(Contract):
         attrs = tokens.get('attrs', None)
         if attrs is not None:
             attrs = {k: v for k, v in attrs.items()}
-        return Object(attrs, where=where)
+        return Attr(attrs, where=where)
 
 attr_spec = Dict(
         delimitedList(
@@ -53,8 +53,8 @@ attr_spec = Dict(
 attrs_spec = ('(' - attr_spec - ')')
 
 
-object_contract = Keyword('object') + O(attrs_spec)
-object_contract.setParseAction(Object.parse_action)
+attr_contract = Keyword('attr') + O(attrs_spec)
+attr_contract.setParseAction(Attr.parse_action)
 
-add_contract(object_contract)
-add_keyword('object')
+add_contract(attr_contract)
+add_keyword('attr')


### PR DESCRIPTION
I added some support for attribute contract statements (example below).
## Example

``` python
import contracts


class A:
    a = 1
    b = 2

a = A()


def test(c):
    print "Testing %s" % c
    print "\t%s" % contracts.check(c, a)
    print "\tPassed"

test('object')
test('object(a:int)')
test('object(a:int;b:int)')
test('object(a:int;b:int,>1)')
```
