### PR TITLE
Allow `contracts` to be imported when numpy is not installed.

### DIFF
--- a/src/contracts/useful_contracts/__init__.py
+++ b/src/contracts/useful_contracts/__init__.py
@@ -1,2 +1,8 @@
-from .numpy_specific import *    
+try:
+    import numpy
+except ImportError:  # pragma: no cover
+    pass
+else:
+    from .numpy_specific import *    
+
 from .numbers import *


### PR DESCRIPTION
I noticed that in the current master (6454b66052),  `import contracts` fails when numpy is not installed:

```
$ git clone git://github.com/AndreaCensi/contracts.git
...

$ virtualenv venv
...

$ venv/bin/python --version                                                                                        
Python 2.7.5

$ venv/bin/pip install ./contracts
...

$ venv/bin/python -c 'import contracts'                                                                            
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/ryan.heimbuch/src/venv/lib/python2.7/site-packages/contracts/__init__.py", line 43, in <module>
    from .useful_contracts import *
  File "/Users/ryan.heimbuch/src/venv/lib/python2.7/site-packages/contracts/useful_contracts/__init__.py", line 1, in <module>
    from .numpy_specific import *
  File "/Users/ryan.heimbuch/src/venv/lib/python2.7/site-packages/contracts/useful_contracts/numpy_specific.py", line 2, in <module>
    import numpy as np
ImportError: No module named numpy
```

I found a conditional import check that used to be present in `src/contracts/useful_contracts/__init__.py` but was [removed in commit cfe9bb78d](https://github.com/AndreaCensi/contracts/commit/cfe9bb78d#L6L2). I feel like this was probably an oversight during the refactoring of the `contracts.useful_contracts` package. I've added back a  try/except/else block around the `from .numpy_specific import *` statement.
