### PR TITLE
allow contracts to be disabled with ENV variable

### DIFF
--- a/src/contracts/enabling.py
+++ b/src/contracts/enabling.py
@@ -1,8 +1,10 @@
 from . import logger
+import os
 
 
 class Switches:
-    disable_all = False
+    # default to ENV variable
+    disable_all = os.environ.get('DISABLE_CONTRACTS', False)
 
 
 def disable_all():
@@ -12,9 +14,13 @@ def disable_all():
 
 
 def enable_all():
-    """ Enables all contracts checks. """
-    Switches.disable_all = False
-    logger.info('All contracts checking enabled.')
+    """
+    Enables all contracts checks.
+    Can be overridden by an environment variable.
+    """
+    if not os.environ.get('DISABLE_CONTRACTS', False):
+        Switches.disable_all = False
+        logger.info('All contracts checking enabled.')
 
 
 def all_disabled():


### PR DESCRIPTION
This PR allows for contracts to be disabled by setting an environment variable, `DISABLE_CONTRACTS`. This feature is useful to have if you want to make sure contracts is disabled for some environments but not for others (like dev vs production).
