### PR TITLE
Support for calllable objects and bound functions

### DIFF
--- a/src/contracts/backported.py
+++ b/src/contracts/backported.py
@@ -8,13 +8,11 @@ else:  # pragma: no cover
     from collections import namedtuple
     FullArgSpec = namedtuple('FullArgSpec', 'args varargs varkw defaults'
                              ' kwonlyargs kwonlydefaults annotations')
-    from inspect import getargspec as _getargspec, isfunction
+    from inspect import getargspec as _getargspec
 
     def getargspec(function):
         # print 'hasattr im_func', hasattr(function, 'im_func')
-        if (hasattr(function, 'im_func') or \
-            (hasattr(function,'__call__') and \
-             hasattr(function.__call__,'im_func'))):
+        if hasattr(function, 'im_func'):
             # print('this is a special function : %s' % function)
             # For methods or classmethods drop the first
             # argument from the returned list because
@@ -23,12 +21,7 @@ else:  # pragma: no cover
             # inspect.getargspec() returns for methods.
             # NB: We use im_func so we work with
             #     instancemethod objects also.
-            
-            if hasattr(function, 'im_func'):
-                x = _getargspec(function.im_func)
-            else:
-                x = _getargspec(function.__call__.im_func)
-
+            x = _getargspec(function.im_func)
             new_args = x.args[1:]
             spec = ArgSpec(args=new_args, varargs=x.varargs,
                            keywords=x.keywords, defaults=x.defaults)

--- a/src/contracts/main.py
+++ b/src/contracts/main.py
@@ -160,6 +160,14 @@ def contracts_decorate(function_, modify_docstring=True, **kwargs):
         The decorator :py:func:`decorate` calls this function internally.
     """
 
+    if hasattr(function_,'__call__') and hasattr(function_.__call__,'im_func'):
+        """ For classes that implement __call__ replace the object with 
+            a bound __call__.
+        """
+        class_name=function_.__class__.__name__
+        function_=function_.__call__
+        function_.__dict__['__name__']=class_name +'.__call__'
+
     if isinstance(function_, classmethod):
         msg = """
 The function is a classmethod; PyContracts cannot decorate a classmethod. 
@@ -308,11 +316,8 @@ you can achieve the same goal by inverting the two decorators:
     contracts_checker.__name__ = 'checker-for-%s' % function_.__name__
     contracts_checker.__module__ = function_.__module__
 
-    # TODO: is using functools.wraps better?
-    # from decorator import decorator
     from functools import partial,wraps
 
-    # wrapper = decorator(contracts_checker,function_)
     wrapper = wraps(function_)(partial(contracts_checker,function_))
 
     wrapper.__doc__ = new_docs


### PR DESCRIPTION
Hi Andrea,

Love the project. This is my first pull request on Github, and note that I am also new to Python in general. I fixed a bug I was getting with bound methods that originated from the imported decorator module. I also added support to callable objects by replacing them with their __call__.  This now runs on 2.7:

``` python
from contracts import contract, ContractNotRespected

class eggs(object):
    def __init__(self,x):
        self.x=x
    def __call__(self,kw1,kw2):
        print str(self.x) + ': kw1='+ str(kw1) + ', kw2=' + str(kw2)
    def bound_func(self,kw1,kw2):
        print str(self.x) + ': kw1='+ str(kw1) + ', kw2=' + str(kw2)

spam=eggs('Hello from within the instance')            
fish=contract(kw1=float,kw2=int)(spam)

print "\nCalling a proper fish"
fish(6.0,5)

print "\nCalling an improper fish"
try:
    fish(6,5.0)
except ContractNotRespected as detail:
    print detail

dead=eggs("And now ...")    
parrot=contract(kw1=float,kw2=int)(dead.bound_func)

print "\nCalling a proper parrot"
parrot(600.0,500)

print "\nCalling an improper parrot"
try:
    parrot(600,500.0)
except ContractNotRespected as detail:
    print detail
```

The output is:

```
Calling a proper fish
Hello from within the instance: kw1=6.0, kw2=5

Calling an improper fish
Breach for argument 'kw1' to __call__().
Expected type 'float', got 'int'.
checking: float   for value: Instance of int: 6   

Calling a proper parrot
And now ...: kw1=600.0, kw2=500

Calling an improper parrot
Breach for argument 'kw1' to bound_func().
Expected type 'float', got 'int'.
checking: float   for value: Instance of int: 600   
```

BTW, I have a branch, ContractAttribute, with a working descriptor for enforcing a contract on an object's static function attribute. Let me know if you are interested.
