### PR TITLE
towards python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: python
+
+python:
+  - 2.7
+  - 3.2
+  - 3.3
+  - 3.4
+  - pypy
+
+matrix:
+  allow_failures:
+    - python: 3.3
+    - python: 3.4
+    - python: pypy
+install:
+  - pip install -r requirements.txt
+
+script:
+  - if [[ $TRAVIS_PYTHON_VERSION == 2* || $TRAVIS_PYTHON_VERSION == "pypy" ]]; then
+        nosetests --ignore-files=test_py3k_annotations.py;
+    else
+        nosetests;
+    fi

--- a/README.rst
+++ b/README.rst
@@ -75,13 +75,12 @@ Any Python type is a contract: ::
     def f(a, b):
         ...
 
-**Enforcing interfaces**:  ``ContractsMeta`` (available for Python 2.x) is a metaclass 
-like ABCMeta that propagates contracts to the subclasses: ::
+**Enforcing interfaces**:  ``ContractsMeta`` is a metaclass,
+like ABCMeta, which propagates contracts to the subclasses: ::
 
-    from contracts import contract, ContractsMeta
+    from contracts import contract, ContractsMeta, with_metaclass
     
-    class Base(object):
-        __metaclass__ = ContractsMeta
+    class Base(with_metaclass(ContractsMeta, object)):
 
         @abstractmethod
         @contract(probability='float,>=0,<=1')

--- a/shippable.yml
+++ b/shippable.yml
@@ -7,7 +7,13 @@ python:
   - 3.3
   - 3.4
   - pypy
-  
+
+matrix:
+  allow_failures:
+    - python: 3.3
+    - python: 3.4
+    - python: "pypy"
+
 install:
   - pip install -r requirements.txt
 

--- a/src/contracts/__init__.py
+++ b/src/contracts/__init__.py
@@ -47,7 +47,7 @@ from .utils import *
 # After everything is loaded, load aliases
 from .library import miscellaneous_aliases
 
-from .metaclass import ContractsMeta
+from .metaclass import ContractsMeta, with_metaclass
 
 ContractsMeta.__module__ = 'contracts'
 

--- a/src/contracts/backported.py
+++ b/src/contracts/backported.py
@@ -1,8 +1,9 @@
 import sys
 from inspect import ArgSpec
 
-if sys.version_info[0] == 3:  # pragma: no cover
+if sys.version_info[0] >= 3:  # pragma: no cover
     from inspect import getfullargspec
+    unicode = str
 
 else:  # pragma: no cover
     from collections import namedtuple
@@ -51,7 +52,7 @@ else:  # pragma: no cover
 
     def getcallargs(func, *positional, **named):
         """Get the mapping of arguments to values.
-    
+
         A dict is returned, with keys the function argument names (including the
         names of the * and ** arguments, if any), and values the respective bound
         values from 'positional' and 'named'.

--- a/src/contracts/interface.py
+++ b/src/contracts/interface.py
@@ -2,6 +2,7 @@ from abc import ABCMeta, abstractmethod
 import sys
 
 from .syntax import col, lineno
+from .metaclass import with_metaclass
 
 
 class Where(object):
@@ -101,7 +102,7 @@ class ContractNotRespected(ContractException):
 
     def __str__(self):
         msg = str(self.error)
-        
+
         def context_to_string(context):
             keys = sorted(context)
             try:
@@ -142,8 +143,7 @@ def format_table(rows, colspacing=1):
     return s
 
 
-class RValue(object):
-    __metaclass__ = ABCMeta
+class RValue(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def eval(self, context):  # @UnusedVariable @ReservedAssignment
@@ -172,8 +172,7 @@ def eval_in_context(context, value, contract):
         raise ContractNotRespected(contract, msg, value, context)
 
 
-class Contract(object):
-    __metaclass__ = ABCMeta
+class Contract(with_metaclass(ABCMeta, object)):
 
     def __init__(self, where):
         assert ((where is None) or

--- a/src/contracts/syntax.py
+++ b/src/contracts/syntax.py
@@ -67,13 +67,13 @@ def isnumber(x):
     # These are scalar quantities that we can compare (=,>,>=, etc.)
     if isinstance(x, Number):
         return True
-    try: 
+    try:
         # Slow, do it only once (TODO)
         import numpy
         return isinstance(x, numpy.number)
-    except:
+    except ImportError:
         return False
-    
+
 
 rvalue = Forward()
 rvalue.setName('rvalue')
@@ -94,7 +94,7 @@ number = pi | floatnumber | integer
 operand = number | int_variables_ref | misc_variables_ref | scoped_variables_ref
 operand.setName('r-value')
 
- 
+
 op = operatorPrecedence
 # op  = myOperatorPrecedence
 rvalue << op(operand, [
@@ -106,10 +106,10 @@ rvalue << op(operand, [
 
 
 
-# I want 
+# I want
 # - BindVariable to have precedence to EqualTo(VariableRef)
 # but I also want:
-# - Arithmetic to have precedence w.r.t BindVariable 
+# - Arithmetic to have precedence w.r.t BindVariable
 # last is variables
 add_contract(misc_variables_contract)
 add_contract(int_variables_contract)

--- a/src/contracts/testing/test_meta.py
+++ b/src/contracts/testing/test_meta.py
@@ -1,10 +1,11 @@
 from abc import abstractmethod
-from contracts import ContractNotRespected, contract, ContractsMeta
-import unittest
-from contracts import CannotDecorateClassmethods
 import functools
 import nose
+import unittest
 
+from contracts import ContractNotRespected, contract, ContractsMeta
+from contracts import CannotDecorateClassmethods
+from contracts import with_metaclass
 
 def expected_failure(test):
     @functools.wraps(test)
@@ -21,118 +22,112 @@ def expected_failure(test):
 class TestMeta(unittest.TestCase):
 
     def test_meta_still_works1(self):
-        
-        class A():
-            __metaclass__ = ContractsMeta
-            
+
+        class A(with_metaclass(ContractsMeta, object)):
+
             @abstractmethod
             @contract(a='>0')
             def f(self, a):
                 pass
-        
+
         class B(A):
             # does not implement f
             pass
-        
+
         self.assertRaises(TypeError, B)
-        
+
     def test_meta_still_works2(self):
-        
-        class A():
-            __metaclass__ = ContractsMeta
-            
+
+        class A(with_metaclass(ContractsMeta, object)):
+
             # inverse order
             @contract(a='>0')
             @abstractmethod
             def f(self, a):
                 pass
-        
+
         class B(A):
             # does not implement f
             pass
-            
-        
+
+
         self.assertRaises(TypeError, B)
-        
+
     def test_meta1(self):
-        
-        class A():
-            __metaclass__ = ContractsMeta
-            
+
+        class A(with_metaclass(ContractsMeta, object)):
+
             @abstractmethod
             @contract(a='>0')
             def f(self, a):
                 pass
-            
-            
+
+
             @contract(a='>0')
             @abstractmethod
             def g(self, a):
                 pass
-            
+
         class B(A):
-            
+
             def f(self, a):
                 pass
-            
+
             def g(self, a):
                 pass
-        
+
         b = B()
-  
+
         self.assertRaises(ContractNotRespected, b.f, 0)
         self.assertRaises(ContractNotRespected, b.g, 0)
 
     @expected_failure
     def test_static1(self):
-        
-        class A():
-            __metaclass__ = ContractsMeta
-            
+
+        class A(with_metaclass(ContractsMeta, object)):
+
             @staticmethod
             @contract(a='>0')
             def f(a):
                 pass
-            
+
         self.assertRaises(ContractNotRespected, A.f, 0)
-        
+
         class B(A):
-            
+
             @staticmethod
             def f(a):
                 pass
-  
-        self.assertRaises(ContractNotRespected, B.f, 0) # this doesn't work  
-        
-    @expected_failure   
+
+        self.assertRaises(ContractNotRespected, B.f, 0) # this doesn't work
+
+    @expected_failure
     def test_classmethod1(self):
-        
-        class A():
-            __metaclass__ = ContractsMeta
-            
+
+        class A(with_metaclass(ContractsMeta, object)):
+
             @classmethod
             @contract(a='>0')
-            def f(cls, a):  
+            def f(cls, a):
                 print('called A.f(%s)' % a)
                 pass
 
         self.assertRaises(ContractNotRespected, A.f, 0)
-            
+
         class B(A):
-            
+
             @classmethod
             def f(cls, a):
                 print('called B.f(%s)' % a)
                 pass
 
-        self.assertRaises(ContractNotRespected, B.f, 0) # this doesn't work  
+        self.assertRaises(ContractNotRespected, B.f, 0) # this doesn't work
 
     @expected_failure
     def test_classmethod1ns(self):
-    
-        class A(object):
-            __metaclass__ = ContractsMeta
-            
+
+        class A(with_metaclass(ContractsMeta, object)):
+
             @classmethod
             @contract(a='>0')
             def f(cls, a):
@@ -140,36 +135,35 @@ class TestMeta(unittest.TestCase):
                 pass
 
         self.assertRaises(ContractNotRespected, A.f, 0)
-            
+
         class B(A):
-            
+
             @classmethod
             def f(cls, a):
                 print('called B.f(%s)' % a)
                 pass
 
-        self.assertRaises(ContractNotRespected, B.f, 0) # this doesn't work  
-        
+        self.assertRaises(ContractNotRespected, B.f, 0) # this doesn't work
+
 
     def test_classmethod2a(self):
-         
+
         def test_classmethod2():
-            
-            class A():
-                __metaclass__ = ContractsMeta
-                
+
+            class A(with_metaclass(ContractsMeta, object)):
+
                 @contract(a='>0')
                 @classmethod
                 def f(cls, a):
                     pass
-                
+
             class B(A):
-                
+
                 @classmethod
                 def f(cls, a):
                     pass
-      
+
         self.assertRaises(CannotDecorateClassmethods, test_classmethod2)
-      
-       
+
+
 

--- a/src/contracts/testing/test_new_contract.py
+++ b/src/contracts/testing/test_new_contract.py
@@ -4,7 +4,7 @@ from contracts import new_contract, check, Contract, contract
 from contracts.library.extensions import identifier_expression
 
 from .utils import check_contracts_fail, check_contracts_ok
-from contracts.main import  can_be_used_as_a_type
+from contracts.main import can_be_used_as_a_type, Storage
 from contracts.syntax import ParsingTmp
 
 # The different patterns
@@ -38,6 +38,9 @@ def cname():
 
 class TestNewContract(unittest.TestCase):
     counter = 0
+
+    #def setup(self):
+    #    Storage.string2contract = {}
 
     def test_inverted_args(self):
         self.assertRaises(ValueError, new_contract, ok1, 'list')
@@ -117,7 +120,7 @@ class TestNewContract(unittest.TestCase):
     def test_other_pass(self):
         class Ex1(Exception):
             pass
-        
+
         def invalid(x):
             raise Ex1()
         c = cname()
@@ -126,7 +129,7 @@ class TestNewContract(unittest.TestCase):
 
     def test_callable(self):
         class MyTest_ok(object):
-            def __call__(self, x):  # @UnusedVariable 
+            def __call__(self, x):  # @UnusedVariable
                 return True
         o = MyTest_ok()
         assert o('value') == True
@@ -134,7 +137,7 @@ class TestNewContract(unittest.TestCase):
 
     def test_callable_old_style(self):
         class MyTest_ok():
-            def __call__(self, x):  # @UnusedVariable 
+            def __call__(self, x):  # @UnusedVariable
                 return True
         o = MyTest_ok()
         assert o('value') == True
@@ -144,31 +147,31 @@ class TestNewContract(unittest.TestCase):
         # This should be interpreted as a type
         # init(x,y) so it is not mistaken for a valid callable
         class NewStyleClass(object):
-            def __init__(self, x, y):  # @UnusedVariable 
+            def __init__(self, x, y):  # @UnusedVariable
                 pass
         new_contract(cname(), NewStyleClass)
 
     def test_class_as_contract2(self):
         # old sytle class
         class OldStyleClass():
-            def __init__(self, x, y):  # @UnusedVariable 
+            def __init__(self, x, y):  # @UnusedVariable
                 pass
         new_contract(cname(), OldStyleClass)
 
     def test_class_as_contract3(self):
         class NewStyleClass(object):
-            def __init__(self, x, y):  # @UnusedVariable 
+            def __init__(self, x, y):  # @UnusedVariable
                 pass
-            
+
         @contract(x=NewStyleClass)
         def f(x):
             pass
 
     def test_class_as_contract4(self):
         class OldStyleClass():
-            def __init__(self, x, y):  # @UnusedVariable 
+            def __init__(self, x, y):  # @UnusedVariable
                 pass
-            
+
         @contract(x=OldStyleClass)
         def f(x):
             pass
@@ -186,7 +189,7 @@ class TestNewContract(unittest.TestCase):
 #        class MyTest_fail(object):
 #            def __call__(self, x, y):  # @UnusedVariable
 #                return True
-#            
+#
 #        self.assertRaises(ValueError, new_contract, cname(), MyTest_fail())
 
     def test_lambda_2(self):
@@ -198,6 +201,7 @@ class TestNewContract(unittest.TestCase):
         self.assertRaises(ValueError, new_contract, cname(), f)
 
     def test_idioms(self):
+        Storage.string2contract = {}  # TODO remove this hack
         color = new_contract('color', 'list[3](number,>=0,<=1)')
         # Make sure we got it right
         color.check([0, 0, 0])
@@ -211,7 +215,7 @@ class TestNewContract(unittest.TestCase):
         @contract
         def fill_area(inside, border):
             """ Fill the area inside the current figure.
-            
+
                 :type border: color
                 :type inside: color
             """
@@ -220,7 +224,7 @@ class TestNewContract(unittest.TestCase):
         @contract
         def fill_gradient(colors):
             """ Use a gradient to fill the area.
-            
+
                 :type colors: list(color)
             """
             pass
@@ -246,7 +250,7 @@ class TestNewContract(unittest.TestCase):
         p = parse('even2')
         p.check(2)
         p.fail(3)
-        p.fail(2.0) # now fails 
+        p.fail(2.0) # now fails
 
     def test_types_as_contracts(self):
         c = cname()
@@ -262,13 +266,13 @@ class TestNewContract(unittest.TestCase):
 
     def test_well_recognized(self):
         class OldStyleClass():
-            def __init__(self, x, y):  # @UnusedVariable 
+            def __init__(self, x, y):  # @UnusedVariable
                 pass
 
         assert can_be_used_as_a_type(OldStyleClass)
 
         class NewStyleClass():
-            def __init__(self, x, y):  # @UnusedVariable 
+            def __init__(self, x, y):  # @UnusedVariable
                 pass
 
         assert can_be_used_as_a_type(NewStyleClass)

--- a/src/contracts/utils.py
+++ b/src/contracts/utils.py
@@ -17,18 +17,18 @@ def indent(s, prefix, first=None):
     assert isinstance(prefix, str)
     lines = s.split('\n')
     if not lines: return ''
-    
+
     if first is None:
         first= prefix
-    
+
     m = max(len(prefix), len(first))
-    
+
     prefix = ' ' * (m-len(prefix)) + prefix
     first = ' ' * (m-len(first)) +first
-    
+
     # differnet first prefix
     res = ['%s%s' % (prefix, line.rstrip()) for line in lines]
-    res[0] = '%s%s' % (first, lines[0].rstrip())     
+    res[0] = '%s%s' % (first, lines[0].rstrip())
     return '\n'.join(res)
 
 def deprecated(func):
@@ -48,7 +48,7 @@ def check_isinstance(ob, expected, **kwargs):
     if not isinstance(ob, expected):
         kwargs['object'] = ob
         raise_type_mismatch(ob, expected, **kwargs)
-    
+
 def raise_type_mismatch(ob, expected, **kwargs):
     """ Raises an exception concerning ob having the wrong type. """
     e = 'Object not of expected type:'
@@ -65,57 +65,56 @@ def format_obs(d):
     from contracts.interface import describe_value_multiline
 
 
-    
+
     maxlen = 0
     for name in d:
         maxlen = max(len(name), maxlen)
-        
+
     def pad(pre):
         return ' ' * (maxlen-len(pre)) + pre
-    
+
     res = ''
     for i, (name, value) in enumerate(d.items()):
         prefix = pad('%s: ' % name)
         if i > 0:
             res += '\n'
-        res +=  indent(describe_value_multiline(value), 
+        res +=  indent(describe_value_multiline(value),
                              ' ', first=prefix)
-        
+
     return res
 
 
 def raise_wrapped(etype, e, msg, **kwargs):
-    """ Raises an exception of type etype by wrapping 
+    """ Raises an exception of type etype by wrapping
         another exception "e" with its backtrace and adding
         the objects in kwargs as formatted by format_obs.
     """
     assert isinstance(e, BaseException), type(e)
     assert isinstance(msg, str), type(msg)
-    s = msg 
+    s = msg
     if kwargs:
         s += '\n' + format_obs(kwargs)
-    
+
     import sys
     if sys.version_info[0] >= 3:
         es = str(e)
     else:
         es = traceback.format_exc(e)
 
-    
-    s += '\n' + indent(es.strip(), '| ')
-    
-    raise etype(s)
 
-# 
-# 
-# 
+    s += '\n' + indent(es.strip(), '| ')
+
+    raise etype(s)
+#
+#
+#
 # def format_tb(tb, limit = None):
 #     """A shorthand for 'format_list(extract_stack(f, limit))."""
 #     return format_list(extract_tb(tb, limit))
-# 
+#
 # def extract_tb(tb, limit = None):
 #     """Return list of up to limit pre-processed entries from traceback.
-# 
+#
 #     This is useful for alternate formatting of stack traces.  If
 #     'limit' is omitted or None, all entries are extracted.  A
 #     pre-processed stack trace entry is a quadruple (filename, line


### PR DESCRIPTION
add a with_metaclass top level function which allows metaclass to work
syntactically in both python 2 and python 3.

don't test the python 3 only syntax test file with python 2.

---

The remaining failing tests are `contracts.interface.ContractSyntaxError`s.
It's unclear why these are failing, they appear to be stateful (as the
code works correctly outside of the context of the test suite!). Could this
be caching related?

*Note: Sometimes the tests do pass on python 3.3 and 3.4!!*