### PR TITLE
Allow file to be used as a contract type

### DIFF
--- a/src/contracts/library/__init__.py
+++ b/src/contracts/library/__init__.py
@@ -9,7 +9,8 @@ from .tuple import Tuple
 from .dicts import Dict
 from .map import Map
 from .sets import *
-from .attributes import Attr 
+from .attributes import Attr
+from .files import File
 
 
 from .comparison import CheckOrder

--- a/src/contracts/library/files.py
+++ b/src/contracts/library/files.py
@@ -1,0 +1,37 @@
+import io
+import sys
+
+from ..interface import Contract, ContractNotRespected
+from ..syntax import (add_contract, add_keyword, Keyword, W)
+
+if sys.version_info[0] > 2:
+    file_type = io.IOBase
+else:
+    file_type = (file, io.IOBase)
+
+class File(Contract):
+
+    def check_contract(self, context, value):
+        if not isinstance(value, file_type):
+            error = 'Expected a file, got %r.' % value.__class__.__name__
+            raise ContractNotRespected(contract=self, error=error,
+                                       value=value, context=context)
+
+    def __str__(self):
+        return 'file'
+
+    def __repr__(self):
+        return 'File()'
+
+    @staticmethod
+    def parse_action(s, loc, _):
+        where = W(s, loc)
+        return File(where=where)
+
+
+file_contract = Keyword('file')
+
+file_contract.setParseAction(File.parse_action)
+
+add_contract(file_contract)
+add_keyword('file')

--- a/src/contracts/library/files.py
+++ b/src/contracts/library/files.py
@@ -1,15 +1,21 @@
+# TODO: handle file mode?
+
 import io
 import sys
 
 from ..interface import Contract, ContractNotRespected
 from ..syntax import (add_contract, add_keyword, Keyword, W)
 
-if sys.version_info[0] > 2:
-    file_type = io.IOBase
-else:
+inPy2 = sys.version_info[0] == 2
+if inPy2:
     file_type = (file, io.IOBase)
+else:
+    file_type = io.IOBase
 
 class File(Contract):
+
+    def __init__(self, where=None):
+        Contract.__init__(self, where)
 
     def check_contract(self, context, value):
         if not isinstance(value, file_type):

--- a/src/contracts/testing/library/__init__.py
+++ b/src/contracts/testing/library/__init__.py
@@ -15,6 +15,7 @@ from . import simple_values_tc
 from . import map_tc
 from . import seq_tc
 from . import attr_tc
+from . import files_tc
 
 from . import isinstance_tc 
 

--- a/src/contracts/testing/library/files_tc.py
+++ b/src/contracts/testing/library/files_tc.py
@@ -1,0 +1,10 @@
+import io
+
+from . import syntax_fail, good, fail
+
+good('file', io.IOBase())
+fail('file', 1)
+fail('file', [])
+syntax_fail('file[]')
+syntax_fail('file[]()')
+syntax_fail('file()')


### PR DESCRIPTION
Allow `file` to be used as a contract type within docstrings/text contracts, for example:

    @contract
    def file_test(in_):
        """Ensure that the file contract works.
   
       :type in_: file

        """
        return in_.read() 

This should resolve #36.