### PR TITLE
Pin requirements to avoid breaking builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyparsing 
-decorator
-six
+pyparsing==2.1.5
+decorator==4.0.10
+six==1.10.0


### PR DESCRIPTION
This addresses issue #50 short term. In general I think it's best to pin packages to specific version so that dependent projects do not break during upgrades. Long term a fix for the `pycontracts` change would be best :)
