### PR TITLE
Remove basicConfig() call from the top level

### DIFF
--- a/src/contracts/__init__.py
+++ b/src/contracts/__init__.py
@@ -2,7 +2,6 @@ __version__ = '1.7.15'
 
 import logging
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 from .interface import (Contract, ContractNotRespected,


### PR DESCRIPTION
it is preventing users of this library from calling basicConfig
themselves.