### PR TITLE
Please do not call basicConfig for the root logger

### DIFF
--- a/src/contracts/__init__.py
+++ b/src/contracts/__init__.py
@@ -2,7 +2,6 @@ __version__ = '1.7.15'
 
 import logging
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 from .interface import (Contract, ContractNotRespected,


### PR DESCRIPTION
If you call basicConfig, I can not change the basicConfig (format, level, etc.) after importing your package, which I typically do up front.