### PR TITLE
Pin decorator package version since it shipped a breaking change for Python2 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(name='PyContracts',
 
       package_dir={'': 'src'},
       packages=find_packages('src'),
-      install_requires=['pyparsing', 'decorator', 'six', 'future'],
+      install_requires=['pyparsing', 'decorator<5', 'six', 'future'],
       tests_require=['nose'],
       entry_points={},
       )


### PR DESCRIPTION
https://github.com/micheles/decorator has dropped python 2 support apparently (commit: https://github.com/micheles/decorator/commit/a615c2ae5fe17c8e1f1a19247ed003986343734a), so anything that is `>=5.0.0` will break python2 compatibility of this package. 😢 