### PR TITLE
Innappropriate import of site-packages rather than contracts source if contracts is installed

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,5 @@
 [bumpversion]
-current_version = 2.0.1
+current_version = 2.0.2
 files = src/contracts/__init__.py
 commit = True
 tag = True
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ decorator==4.0.10
 six==1.10.0
 future
 numpy<1.16
+Cython~=0.29.24
+setuptools~=58.0.4

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 import os
+from glob import glob
+from pathlib import Path
 
 from setuptools import setup, find_packages
-
+from Cython.Build import cythonize
 description = (
     'PyContracts is a Python package that allows to declare '
     'constraints on function parameters and return values. '
@@ -36,10 +38,10 @@ def get_version(filename):
 
 version = get_version(filename='src/contracts/__init__.py')
 
-setup(name='PyContracts',
-      author="Andrea Censi",
+setup(name='contrax',
+      author="Ross J. Duff",
       author_email="censi@mit.edu",
-      url='http://andreacensi.github.com/contracts/',
+      url='http://rjbcm.github.com/contrax/',
 
       description=description,
       long_description=long_description,
@@ -53,7 +55,6 @@ setup(name='PyContracts',
           'Topic :: Software Development :: Quality Assurance',
           'Topic :: Software Development :: Documentation',
           'Topic :: Software Development :: Testing',
-          'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
@@ -62,7 +63,7 @@ setup(name='PyContracts',
 
       version=version,
       download_url='http://github.com/AndreaCensi/contracts/tarball/%s' % version,
-
+      ext_modules=cythonize([fn for fn in glob('src/contracts/*.py') if not Path(fn).name.startswith('_')]),
       package_dir={'': 'src'},
       packages=find_packages('src'),
       install_requires=['pyparsing', 'decorator', 'six', 'future'],

--- a/src/contracts-py3k-test/test_py3k_annotations.py
+++ b/src/contracts-py3k-test/test_py3k_annotations.py
@@ -2,7 +2,7 @@
 # FIXME: how can I not parse this with python2?
 
 import unittest
-from contracts import decorate, ContractException, contract, ContractNotRespected
+from ..contracts import decorate, ContractException, contract, ContractNotRespected
 
 
 #@PydevCodeAnalysisIgnore

--- a/src/contracts/__init__.py
+++ b/src/contracts/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.0.1'
+__version__ = '2.0.2'
 
 import logging
 

--- a/src/contracts/__init__.py
+++ b/src/contracts/__init__.py
@@ -1,23 +1,17 @@
-__version__ = '2.0.2'
-
-import logging
-
-#logging.basicConfig()
-logger = logging.getLogger(__name__)
+__version__ = '2.0.1'
 
 from .interface import (Contract, ContractNotRespected,
                         CannotDecorateClassmethods,
                         ContractSyntaxError, ContractException)
 
-from .main import (check, fail, check_multiple, contract_decorator,
+from .main import (contract_decorator, check, fail, check_multiple,
                    contracts_decorate as decorate,
                    parse_flexible_spec as parse)
 
 
 # Just make them appear as belonging to the "contracts" Module
 # So that Eclipse and other IDEs will not get confused.
-def contract(*args, **kwargs):
-    return contract_decorator(*args, **kwargs)
+contract = contract_decorator  # type: ignore
 
 contract.__doc__ = contract_decorator.__doc__
 
@@ -30,8 +24,6 @@ def new_contract(*args):
 
 new_contract.__doc__ = new_contract_main.__doc__
 
-from .enabling import disable_all, enable_all, all_disabled
-
 # A couple of useful functions
 from .interface import describe_value, describe_type, describe_value_multiline
 from .utils import *
@@ -43,4 +35,4 @@ ContractsMeta.__module__ = 'contracts'
 # And after everything else is loaded, load the  utils
 from .useful_contracts import *
 # After everything is loaded, load aliases
-# from .library import miscellaneous_aliases  # @UnusedImport
+from .library import miscellaneous_aliases  # @UnusedImport

--- a/src/contracts/_compat.py
+++ b/src/contracts/_compat.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Modified to work as a lightweight alternative to vendoring six.
+# Originally from the package RestrictedPython.
+# Copyright (c) 2002 Zope Foundation and Contributors.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+##############################################################################
+
+import platform
+import sys
+
+_version = sys.version_info
+IS_PY2 = _version.major == 2
+IS_PY3 = _version.major == 3
+IS_PY34_OR_GREATER = _version.major == 3 and _version.minor >= 4
+IS_PY35_OR_GREATER = _version.major == 3 and _version.minor >= 5
+IS_PY36_OR_GREATER = _version.major == 3 and _version.minor >= 6
+IS_PY37_OR_GREATER = _version.major == 3 and _version.minor >= 7
+IS_PY38_OR_GREATER = _version.major == 3 and _version.minor >= 8
+IS_PY3A_OR_GREATER = _version.major == 3 and _version.minor >= 10
+
+if IS_PY2:  # pragma: no cover
+    basestring = basestring  # NOQA: F821  # Python 2 only built-in function
+else:  # pragma: PY3
+    basestring = str
+
+if IS_PY2:  # pragma: no cover
+    unicode = unicode # NOQA: F821  # Python 2 only built-in function
+else:
+    unicode = str
+
+IS_CPYTHON = platform.python_implementation() == 'CPython'

--- a/src/contracts/docstring_parsing.py
+++ b/src/contracts/docstring_parsing.py
@@ -1,4 +1,7 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 import re
+
+import cython
 
 
 class Arg(object):
@@ -76,7 +79,6 @@ class DocStringInfo(object):
         type_keys = ['type']
         return_keys = ['returns', 'return']
         rtype_keys = ['rtype']
-        # TODO: document state?
         # var_keys = ['var', 'ivar', 'cvar']
         # raises, raise, except, exception
 
@@ -120,28 +122,26 @@ def parse_annotations(docstring, keys, empty=False, inline_type=False):
 
     found = {}
 
+    def replace(match):
+        d = match.groupdict()
+
+        if empty:
+            name = len(found)
+        else:
+            name = d['name'] or None
+
+        if inline_type:
+            found[name] = (d['type'] or None, d['desc'] or None)
+        else:
+            found[name] = d['desc'] or None
+        return ""
+
     for key in keys:
         if empty:
-            regexp = ('^\s*:\s*%s(?P<type>[^:]*?)\s*:\s*(?P<desc>.*?)\s*$'
-                      % key)
+            regexp = fr'^\s*:\s*{key}(?P<type>[^:]*?)\s*:\s*(?P<desc>.*?)\s*$'
         else:
-            regexp = ('^\s*:\s*%s\s+(?P<type>[^:]*?)(?P<name>[^\s:]+)\s*:'
-                      '\s*(?P<desc>.*?)\s*$' % key)
+            regexp = rf'^\s*:\s*{key}\s+(?P<type>[^:]*?)(?P<name>[^\s:]+)\s*:\s*(?P<desc>.*?)\s*$'
         regexp = re.compile(regexp, re.MULTILINE)
-
-        def replace(match):
-            d = match.groupdict()
-
-            if empty:
-                name = len(found)
-            else:
-                name = d['name'] or None
-
-            if inline_type:
-                found[name] = (d['type'] or None, d['desc'] or None)
-            else:
-                found[name] = d['desc'] or None
-            return ""
 
         docstring = regexp.sub(repl=replace, string=docstring)
 
@@ -149,6 +149,8 @@ def parse_annotations(docstring, keys, empty=False, inline_type=False):
 
 
 def number_of_spaces(x):
+    x: cython.int
+    i: cython.int
     for i in range(1, len(x)):
         if x[:i] != ' ' * i:
             return i - 1

--- a/src/contracts/inspection.py
+++ b/src/contracts/inspection.py
@@ -1,37 +1,958 @@
-import sys
-import inspect
-from .backported import getcallargs, getfullargspec
+# cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=True, initializedcheck=False
+"""Get useful information from live Python objects.
+This is a statically compiled version of the inspect module from the standard library.
 
+This module encapsulates the interface provided by the internal special
+attributes (co_*, im_*, tb_*, etc.) in a friendlier fashion.
+It also provides some help for examining source code and class layout.
+
+Here are some of the useful functions provided by this module:
+
+    ismodule(), isclass(), ismethod(), isfunction(), isgeneratorfunction(),
+        isgenerator(), istraceback(), isframe(), iscode(), isbuiltin(),
+        isroutine() - check object types
+    getmembers() - get members of an object that satisfy a given condition
+
+    getfile(), getsourcefile(), getsource() - find an object's source code
+    getdoc(), getcomments() - get documentation on an object
+    getmodule() - determine the module that an object came from
+    getclasstree() - arrange classes so as to represent their hierarchy
+
+    getargvalues(), getcallargs() - get info about function arguments
+    getfullargspec() - same, with support for Python 3 features
+    formatargvalues() - format an argument spec
+    getouterframes(), getinnerframes() - get info about frames
+    currentframe() - get the current stack frame
+    stack(), trace() - get info about frames on the stack or in a traceback
+
+    signature() - get a Signature object for the callable
+"""
+
+import ast
+import dis
+import enum
+import importlib.machinery
+import linecache
+import os
+import re
+import sys
+import types
+import warnings
+from collections import namedtuple
+from typing import Callable
+from inspect import FullArgSpec, getfullargspec
 
 inPy2 = sys.version_info[0] == 2
-if inPy2:
-    from types import ClassType
+
+# Create constants for the compiler flags in Include/code.h
+# We try to get them from dis to avoid duplication
+mod_dict = globals()
+for k, v in dis.COMPILER_FLAG_NAMES.items():
+    mod_dict["CO_" + v] = k
+
+# See Include/object.h
+TPFLAGS_IS_ABSTRACT = 1 << 20
 
 
-def can_be_used_as_a_type(x):
-    """ Checks that x can be used as a type; specifically,
-        we can write isintance(y,x).
-        Here we support old-style classes.
+# ----------------------------------------------------------- type-checking
+def ismodule(obj):
+    """Return true if the object is a module.
+
+    Module objects provide these attributes:
+        __cached__      pathname to byte compiled file
+        __doc__         documentation string
+        __file__        filename (missing for built-in modules)"""
+    return isinstance(obj, types.ModuleType)
+
+
+def isclass(obj):
+    """Return true if the object is a class.
+
+    Class objects provide these attributes:
+        __doc__         documentation string
+        __module__      name of module in which this class was defined"""
+    return isinstance(obj, type)
+
+
+def ismethod(obj):
+    """Return true if the object is an instance method.
+
+    Instance method objects provide these attributes:
+        __doc__         documentation string
+        __name__        name with which this method was defined
+        __func__        function object containing implementation of method
+        __self__        instance to which this method is bound"""
+    return isinstance(obj, types.MethodType)
+
+
+def isfunction(object):
+    """Return true if the object is a user-defined function.
+
+    Function objects provide these attributes:
+        __doc__         documentation string
+        __name__        name with which this function was defined
+        __code__        code object containing compiled function bytecode
+        __defaults__    tuple of any default values for arguments
+        __globals__     global namespace in which this function was defined
+        __annotations__ dict of parameter annotations
+        __kwdefaults__  dict of keyword only parameters with defaults"""
+    return isinstance(object, types.FunctionType)
+
+
+def istraceback(object):
+    """Return true if the object is a traceback.
+
+    Traceback objects provide these attributes:
+        tb_frame        frame object at this level
+        tb_lasti        index of last attempted instruction in bytecode
+        tb_lineno       current line number in Python source code
+        tb_next         next inner traceback object (called by this level)"""
+    return isinstance(object, types.TracebackType)
+
+
+def isframe(object):
+    """Return true if the object is a frame object.
+
+    Frame objects provide these attributes:
+        f_back          next outer frame object (this frame's caller)
+        f_builtins      built-in namespace seen by this frame
+        f_code          code object being executed in this frame
+        f_globals       global namespace seen by this frame
+        f_lasti         index of last attempted instruction in bytecode
+        f_lineno        current line number in Python source code
+        f_locals        local namespace seen by this frame
+        f_trace         tracing function for this frame, or None"""
+    return isinstance(object, types.FrameType)
+
+
+def iscode(object):
+    """Return true if the object is a code object.
+
+    Code objects provide these attributes:
+        co_argcount         number of arguments (not including *, ** args
+                            or keyword only arguments)
+        co_code             string of raw compiled bytecode
+        co_cellvars         tuple of names of cell variables
+        co_consts           tuple of constants used in the bytecode
+        co_filename         name of file in which this code object was created
+        co_firstlineno      number of first line in Python source code
+        co_flags            bitmap: 1=optimized | 2=newlocals | 4=*arg | 8=**arg
+                            | 16=nested | 32=generator | 64=nofree | 128=coroutine
+                            | 256=iterable_coroutine | 512=async_generator
+        co_freevars         tuple of names of free variables
+        co_posonlyargcount  number of positional only arguments
+        co_kwonlyargcount   number of keyword only arguments (not including ** arg)
+        co_lnotab           encoded mapping of line numbers to bytecode indices
+        co_name             name with which this code object was defined
+        co_names            tuple of names of local variables
+        co_nlocals          number of local variables
+        co_stacksize        virtual machine stack space required
+        co_varnames         tuple of names of arguments and local variables"""
+    return isinstance(object, types.CodeType)
+
+
+def getfile(object):
+    """Work out which source or compiled file an object was defined in."""
+    if ismodule(object):
+        if getattr(object, '__file__', None):
+            return object.__file__
+        raise TypeError('{!r} is a built-in module'.format(object))
+    if isclass(object):
+        if hasattr(object, '__module__'):
+            module = sys.modules.get(object.__module__)
+            if getattr(module, '__file__', None):
+                return module.__file__
+        raise TypeError('{!r} is a built-in class'.format(object))
+    if ismethod(object):
+        object = object.__func__
+    if isfunction(object):
+        object = object.__code__
+    if istraceback(object):
+        object = object.tb_frame
+    if isframe(object):
+        object = object.f_code
+    if iscode(object):
+        return object.co_filename
+    raise TypeError('module, class, method, function, traceback, frame, or '
+                    'code object was expected, got {}'.format(type(object).__name__))
+
+
+Arguments = namedtuple('Arguments', 'args, varargs, varkw')
+
+
+def getabsfile(object, _filename=None):
+    """Return an absolute path to the source or compiled file for an object.
+
+    The idea is for each object to have a unique origin, so this routine
+    normalizes the result as much as possible."""
+    if _filename is None:
+        _filename = getsourcefile(object) or getfile(object)
+    return os.path.normcase(os.path.abspath(_filename))
+
+
+modulesbyfile = {}
+_filesbymodname = {}
+
+
+def getmodule(object, _filename=None):
+    """Return the module an object was defined in, or None if not found."""
+    if ismodule(object):
+        return object
+    if hasattr(object, '__module__'):
+        return sys.modules.get(object.__module__)
+    # Try the filename to modulename cache
+    if _filename is not None and _filename in modulesbyfile:
+        return sys.modules.get(modulesbyfile[_filename])
+    # Try the cache again with the absolute file name
+    try:
+        file = getabsfile(object, _filename)
+    except TypeError:
+        return None
+    if file in modulesbyfile:
+        return sys.modules.get(modulesbyfile[file])
+    # Update the filename to module name cache and check yet again
+    # Copy sys.modules in order to cope with changes while iterating
+    for modname, module in sys.modules.copy().items():
+        if ismodule(module) and hasattr(module, '__file__'):
+            f = module.__file__
+            if f == _filesbymodname.get(modname, None):
+                # Have already mapped this module, so skip it
+                continue
+            _filesbymodname[modname] = f
+            f = getabsfile(module)
+            # Always map to the name the module knows itself by
+            modulesbyfile[f] = modulesbyfile[
+                os.path.realpath(f)] = module.__name__
+    if file in modulesbyfile:
+        return sys.modules.get(modulesbyfile[file])
+    # Check the main module
+    main = sys.modules['__main__']
+    if not hasattr(object, '__name__'):
+        return None
+    if hasattr(main, object.__name__):
+        mainobject = getattr(main, object.__name__)
+        if mainobject is object:
+            return main
+    # Check builtins
+    builtin = sys.modules['builtins']
+    if hasattr(builtin, object.__name__):
+        builtinobject = getattr(builtin, object.__name__)
+        if builtinobject is object:
+            return builtin
+
+
+def getsourcefile(object):
+    """Return the filename that can be used to locate an object's source.
+    Return None if no way can be identified to get the source.
     """
-    if isinstance(x, type):
-        return True
+    filename = getfile(object)
+    all_bytecode_suffixes = importlib.machinery.DEBUG_BYTECODE_SUFFIXES[:]
+    all_bytecode_suffixes += importlib.machinery.OPTIMIZED_BYTECODE_SUFFIXES[:]
+    if any(filename.endswith(s) for s in all_bytecode_suffixes):
+        filename = (os.path.splitext(filename)[0] +
+                    importlib.machinery.SOURCE_SUFFIXES[0])
+    elif any(filename.endswith(s) for s in
+             importlib.machinery.EXTENSION_SUFFIXES):
+        return None
+    if os.path.exists(filename):
+        return filename
+    # only return a non-existent filename if the module has a PEP 302 loader
+    if getattr(getmodule(object, filename), '__loader__', None) is not None:
+        return filename
+    # or it is in the linecache
+    if filename in linecache.cache:
+        return filename
 
-    if inPy2:
-        if isinstance(x, ClassType):
+
+def getcallargs(func, *positional, **named):
+    f_name: str
+    # noinspection PyUnresolvedReferences
+    assigned_tuple_params: cython.list
+    # noinspection PyUnresolvedReferences
+    arg2dict: cython.dict
+    # noinspection PyUnresolvedReferences
+    num_args: cython.int
+    # noinspection PyUnresolvedReferences
+    num_pos: cython.int
+    # noinspection PyUnresolvedReferences
+    num_total: cython.int
+    # noinspection PyUnresolvedReferences
+    num_defaults: cython.int
+    # noinspection PyUnresolvedReferences
+    num_required: cython.int
+    """Get the mapping of arguments to values.
+
+    A dict is returned, with keys the function argument names (including the
+    names of the * and ** arguments, if any), and values the respective bound
+    values from 'positional' and 'named'.
+    """
+    args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations = getfullargspec(func)
+
+    if kwonlyargs:
+        raise ValueError("I'm sorry, I don't have the logic to use kwonlyargs. "
+                         "Perhapse you can help PyContracts and implement this? Thanks.")
+
+    f_name = func.__name__
+    arg2value = {}
+
+    # The following closures are basically because of tuple
+    # parameter unpacking.
+    assigned_tuple_params = []
+
+    def assign(arg, value):
+        # noinspection PyUnresolvedReferences
+        arg: cython.p_char
+        # noinspection PyUnresolvedReferences
+        i: cython.int
+        nonlocal assigned_tuple_params
+        if isinstance(arg, str):
+            arg2value[arg] = value
+        else:
+            assigned_tuple_params.append(arg)
+            value = iter(value)
+            for i, subarg in enumerate(arg):
+                try:
+                    subvalue = next(value)
+                except StopIteration:
+                    raise ValueError('need more than %d %s to unpack' %
+                                     (i, 'values' if i > 1 else 'value'))
+                assign(subarg, subvalue)
+            try:
+                next(value)
+            except StopIteration:
+                pass
+            else:
+                raise ValueError('too many values to unpack')
+
+    def is_assigned(arg):
+        if isinstance(arg, str):
+            return arg in arg2value
+        return arg in assigned_tuple_params
+
+    im_self = getattr(func, '__self__', None)
+
+    if ismethod(func) and im_self is not None:
+        # implicit 'self' (or 'cls' for classmethods) argument
+        positional = (im_self,) + positional
+    num_pos = len(positional)
+    num_total = num_pos + len(named)
+    num_args = len(args)
+    num_defaults = len(defaults) if defaults else 0
+    for arg, value in zip(args, positional):
+        assign(arg, value)
+    if varargs:
+        if num_pos > num_args:
+            assign(varargs, positional[-(num_pos - num_args):])
+        else:
+            assign(varargs, ())
+    elif 0 < num_args < num_pos:
+        raise TypeError('%s() takes %s %d %s (%d given)' % (
+            f_name, 'at most' if defaults else 'exactly', num_args,
+            'arguments' if num_args > 1 else 'argument', num_total))
+    elif num_args == 0 and num_total:
+        raise TypeError('%s() takes no arguments (%d given)' %
+                        (f_name, num_total))
+    for arg in args:
+        if isinstance(arg, str) and arg in named:
+            if is_assigned(arg):
+                raise TypeError("%s() got multiple values for keyword "
+                                "argument '%s'" % (f_name, arg))
+            else:
+                assign(arg, named.pop(arg))
+    if defaults:  # fill in any missing values with the defaults
+        for arg, value in zip(args[-num_defaults:], defaults):
+            if not is_assigned(arg):
+                assign(arg, value)
+    if varkw:
+        assign(varkw, named)
+    elif named:
+        unexpected = next(iter(named))
+        if isinstance(unexpected, str):
+            unexpected = unexpected.encode(sys.getdefaultencoding(), 'replace')
+        raise TypeError("%s() got an unexpected keyword argument '%s'" %
+                        (f_name, unexpected))
+    unassigned = num_args - len([arg for arg in args if is_assigned(arg)])
+    if unassigned:
+        num_required = num_args - num_defaults
+        raise TypeError('%s() takes %s %d %s (%d given)' % (
+            f_name, 'at least' if defaults else 'exactly', num_required,
+            'arguments' if num_required > 1 else 'argument', num_total))
+    return arg2value
+
+
+ArgSpec = namedtuple('ArgSpec', 'args varargs keywords defaults')
+
+
+def getargspec(func):
+    """Get the names and default values of a function's parameters.
+
+    A tuple of four things is returned: (args, varargs, keywords, defaults).
+    'args' is a list of the argument names, including keyword-only argument names.
+    'varargs' and 'keywords' are the names of the * and ** parameters or None.
+    'defaults' is an n-tuple of the default values of the last n parameters.
+
+    This function is deprecated, as it does not support annotations or
+    keyword-only parameters and will raise ValueError if either is present
+    on the supplied callable.
+
+    For a more structured introspection API, use inspect.signature() instead.
+
+    Alternatively, use getfullargspec() for an API with a similar namedtuple
+    based interface, but full support for annotations and keyword-only
+    parameters.
+
+    Deprecated since Python 3.5, use `inspect.getfullargspec()`.
+    """
+    warnings.warn("inspect.getargspec() is deprecated since Python 3.0, "
+                  "use inspect.signature() or inspect.getfullargspec()",
+                  DeprecationWarning, stacklevel=2)
+    args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, ann = \
+        getfullargspec(func)
+    if kwonlyargs or ann:
+        raise ValueError("Function has keyword-only parameters or annotations"
+                         ", use inspect.signature() API which can support them")
+    return ArgSpec(args, varargs, varkw, defaults)
+
+
+FullArgSpec = namedtuple('FullArgSpec', 'args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations')
+
+ArgInfo = namedtuple('ArgInfo', 'args varargs keywords locals')
+
+
+def formatannotation(annotation, base_module=None):
+    if getattr(annotation, '__module__', None) == 'typing':
+        return repr(annotation).replace('typing.', '')
+    if isinstance(annotation, type):
+        if annotation.__module__ in ('builtins', base_module):
+            return annotation.__qualname__
+        return annotation.__module__ + '.' + annotation.__qualname__
+    return repr(annotation)
+
+
+Traceback = namedtuple('Traceback', 'filename lineno function code_context index')
+
+
+class ClassFoundException(Exception):
+    pass
+
+
+class _ClassFinder(ast.NodeVisitor):
+
+    def __init__(self, qualname):
+        self.stack = []
+        self.qualname = qualname
+
+    def visit_FunctionDef(self, node):
+        self.stack.append(node.name)
+        self.stack.append('<locals>')
+        self.generic_visit(node)
+        self.stack.pop()
+        self.stack.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_ClassDef(self, node):
+        self.stack.append(node.name)
+        if self.qualname == '.'.join(self.stack):
+            # Return the decorator for the class if present
+            if node.decorator_list:
+                line_number = node.decorator_list[0].lineno
+            else:
+                line_number = node.lineno
+
+            # decrement by one since lines starts with indexing by zero
+            line_number -= 1
+            raise ClassFoundException(line_number)
+        self.generic_visit(node)
+        self.stack.pop()
+
+
+def findsource(object):
+    """Return the entire source file and starting line number for an object.
+
+    The argument may be a module, class, method, function, traceback, frame,
+    or code object.  The source code is returned as a list of all the lines
+    in the file and the line number indexes a line in that list.  An OSError
+    is raised if the source code cannot be retrieved."""
+
+    file = getsourcefile(object)
+    if file:
+        # Invalidate cache if needed.
+        linecache.checkcache(file)
+    else:
+        file = getfile(object)
+        # Allow filenames in form of "<something>" to pass through.
+        # `doctest` monkeypatches `linecache` module to enable
+        # inspection, so let `linecache.getlines` to be called.
+        if not (file.startswith('<') and file.endswith('>')):
+            raise OSError('source code not available')
+
+    module = getmodule(object, file)
+    if module:
+        lines = linecache.getlines(file, module.__dict__)
+    else:
+        lines = linecache.getlines(file)
+    if not lines:
+        raise OSError('could not get source code')
+
+    if ismodule(object):
+        return lines, 0
+
+    if isclass(object):
+        qualname = object.__qualname__
+        source = ''.join(lines)
+        tree = ast.parse(source)
+        class_finder = _ClassFinder(qualname)
+        try:
+            class_finder.visit(tree)
+        except ClassFoundException as e:
+            line_number = e.args[0]
+            return lines, line_number
+        else:
+            raise OSError('could not find class definition')
+
+    if ismethod(object):
+        object = object.__func__
+    if isfunction(object):
+        object = object.__code__
+    if istraceback(object):
+        object = object.tb_frame
+    if isframe(object):
+        object = object.f_code
+    if iscode(object):
+        if not hasattr(object, 'co_firstlineno'):
+            raise OSError('could not find function definition')
+        lnum = object.co_firstlineno - 1
+        pat = re.compile(r'^(\s*def\s)|(\s*async\s+def\s)|(.*(?<!\w)lambda(:|\s))|^(\s*@)')
+        while lnum > 0:
+            try:
+                line = lines[lnum]
+            except IndexError:
+                raise OSError('lineno is out of bounds')
+            if pat.match(line):
+                break
+            lnum = lnum - 1
+        return lines, lnum
+    raise OSError('could not find code object')
+
+
+def getframeinfo(frame, context=1):
+    """Get information about a frame or traceback object.
+
+    A tuple of five things is returned: the filename, the line number of
+    the current line, the function name, a list of lines of context from
+    the source code, and the index of the current line within that list.
+    The optional second argument specifies the number of lines of context
+    to return, which are centered around the current line."""
+    if istraceback(frame):
+        lineno = frame.tb_lineno
+        frame = frame.tb_frame
+    else:
+        lineno = frame.f_lineno
+    if not isframe(frame):
+        raise TypeError('{!r} is not a frame or traceback object'.format(frame))
+
+    filename = getsourcefile(frame) or getfile(frame)
+    if context > 0:
+        start = lineno - 1 - context // 2
+        try:
+            lines, lnum = findsource(frame)
+        except OSError:
+            lines = index = None
+        else:
+            start = max(0, min(start, len(lines) - context))
+            lines = lines[start:start + context]
+            index = lineno - 1 - start
+    else:
+        lines = index = None
+
+    return Traceback(filename, lineno, frame.f_code.co_name, lines, index)
+
+
+def getlineno(frame):
+    """Get the line number from a frame object, allowing for optimization."""
+    # FrameType.f_lineno is now a descriptor that grovels co_lnotab
+    return frame.f_lineno
+
+
+FrameInfo = namedtuple('FrameInfo', ('frame',) + Traceback._fields)
+
+
+def getouterframes(frame, context=1):
+    """Get a list of records for a frame and all higher (calling) frames.
+
+    Each record contains a frame object, filename, line number, function
+    name, a list of lines of context, and index within the context."""
+    framelist = []
+    while frame:
+        frameinfo = (frame,) + getframeinfo(frame, context)
+        framelist.append(FrameInfo(*frameinfo))
+        frame = frame.f_back
+    return framelist
+
+
+def getinnerframes(tb, context=1):
+    """Get a list of records for a traceback's frame and all lower frames.
+
+    Each record contains a frame object, filename, line number, function
+    name, a list of lines of context, and index within the context."""
+    framelist = []
+    while tb:
+        frameinfo = (tb.tb_frame,) + getframeinfo(tb, context)
+        framelist.append(FrameInfo(*frameinfo))
+        tb = tb.tb_next
+    return framelist
+
+
+def currentframe():
+    """Return the frame of the caller or None if this is not possible."""
+    return sys._getframe(1) if hasattr(sys, "_getframe") else None
+
+
+def stack(context=1):
+    """Return a list of records for the stack above the caller's frame."""
+    # noinspection PyProtectedMember, PyUnresolvedReferences
+    return getouterframes(sys._getframe(1), context)
+
+
+def trace(context=1):
+    """Return a list of records for the stack below the current exception."""
+    # noinspection PyTypeChecker
+    return getinnerframes(sys.exc_info()[2], context)
+
+
+class _void:
+    """A private marker - used in Parameter & Signature."""
+
+
+class _empty:
+    """Marker object for Signature.empty and Parameter.empty."""
+
+
+class _ParameterKind(enum.IntEnum):
+    POSITIONAL_ONLY = 0
+    POSITIONAL_OR_KEYWORD = 1
+    VAR_POSITIONAL = 2
+    KEYWORD_ONLY = 3
+    VAR_KEYWORD = 4
+
+    def __str__(self):
+        return self._name_
+
+    @property
+    def description(self):
+        return _PARAM_NAME_MAPPING[self]
+
+
+_POSITIONAL_ONLY = _ParameterKind.POSITIONAL_ONLY
+_POSITIONAL_OR_KEYWORD = _ParameterKind.POSITIONAL_OR_KEYWORD
+_VAR_POSITIONAL = _ParameterKind.VAR_POSITIONAL
+_KEYWORD_ONLY = _ParameterKind.KEYWORD_ONLY
+_VAR_KEYWORD = _ParameterKind.VAR_KEYWORD
+
+_PARAM_NAME_MAPPING = {
+    _POSITIONAL_ONLY: 'positional-only',
+    _POSITIONAL_OR_KEYWORD: 'positional or keyword',
+    _VAR_POSITIONAL: 'variadic positional',
+    _KEYWORD_ONLY: 'keyword-only',
+    _VAR_KEYWORD: 'variadic keyword'
+}
+
+
+class Parameter:
+    """Represents a parameter in a function signature.
+
+    Has the following public attributes:
+
+    * name : str
+        The name of the parameter as a string.
+    * default : object
+        The default value for the parameter if specified.  If the
+        parameter has no default value, this attribute is set to
+        `Parameter.empty`.
+    * annotation
+        The annotation for the parameter if specified.  If the
+        parameter has no annotation, this attribute is set to
+        `Parameter.empty`.
+    * kind : str
+        Describes how argument values are bound to the parameter.
+        Possible values: `Parameter.POSITIONAL_ONLY`,
+        `Parameter.POSITIONAL_OR_KEYWORD`, `Parameter.VAR_POSITIONAL`,
+        `Parameter.KEYWORD_ONLY`, `Parameter.VAR_KEYWORD`.
+    """
+
+    __slots__ = ('_name', '_kind', '_default', '_annotation')
+
+    POSITIONAL_ONLY = _POSITIONAL_ONLY
+    POSITIONAL_OR_KEYWORD = _POSITIONAL_OR_KEYWORD
+    VAR_POSITIONAL = _VAR_POSITIONAL
+    KEYWORD_ONLY = _KEYWORD_ONLY
+    VAR_KEYWORD = _VAR_KEYWORD
+
+    empty = _empty
+
+    def __init__(self, name, kind, *, default=_empty, annotation=_empty):
+        try:
+            self._kind = _ParameterKind(kind)
+        except ValueError:
+            raise ValueError(f'value {kind!r} is not a valid Parameter.kind')
+        if default is not _empty:
+            if self._kind in (_VAR_POSITIONAL, _VAR_KEYWORD):
+                msg = '{} parameters cannot have default values'
+                msg = msg.format(self._kind.description)
+                raise ValueError(msg)
+        self._default = default
+        self._annotation = annotation
+
+        if name is _empty:
+            raise ValueError('name is a required attribute for Parameter')
+
+        if not isinstance(name, str):
+            msg = 'name must be a str, not a {}'.format(type(name).__name__)
+            raise TypeError(msg)
+
+        if name[0] == '.' and name[1:].isdigit():
+            # These are implicit arguments generated by comprehensions. In
+            # order to provide a friendlier interface to users, we recast
+            # their name as "implicitN" and treat them as positional-only.
+            # See issue 19611.
+            if self._kind != _POSITIONAL_OR_KEYWORD:
+                msg = (
+                    'implicit arguments must be passed as '
+                    'positional or keyword arguments, not {}'
+                )
+                msg = msg.format(self._kind.description)
+                raise ValueError(msg)
+            self._kind = _POSITIONAL_ONLY
+            name = 'implicit{}'.format(name[1:])
+
+        if not name.isidentifier():
+            raise ValueError('{!r} is not a valid parameter name'.format(name))
+
+        self._name = name
+
+    def __reduce__(self):
+        return (type(self),
+                (self._name, self._kind),
+                {'_default': self._default,
+                 '_annotation': self._annotation})
+
+    def __setstate__(self, state):
+        self._default = state['_default']
+        self._annotation = state['_annotation']
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def default(self):
+        return self._default
+
+    @property
+    def annotation(self):
+        return self._annotation
+
+    @property
+    def kind(self):
+        return self._kind
+
+    def replace(self, *, name=_void, kind=_void,
+                annotation=_void, default=_void):
+        """Creates a customized copy of the Parameter."""
+
+        if name is _void:
+            name = self._name
+
+        if kind is _void:
+            kind = self._kind
+
+        if annotation is _void:
+            annotation = self._annotation
+
+        if default is _void:
+            default = self._default
+
+        return type(self)(name, kind, default=default, annotation=annotation)
+
+    def __str__(self):
+        kind = self.kind
+        formatted = self._name
+
+        # Add annotation and default value
+        if self._annotation is not _empty:
+            formatted = '{}: {}'.format(formatted,
+                                        formatannotation(self._annotation))
+
+        if self._default is not _empty:
+            if self._annotation is not _empty:
+                formatted = '{} = {}'.format(formatted, repr(self._default))
+            else:
+                formatted = '{}={}'.format(formatted, repr(self._default))
+
+        if kind == _VAR_POSITIONAL:
+            formatted = '*' + formatted
+        elif kind == _VAR_KEYWORD:
+            formatted = '**' + formatted
+
+        return formatted
+
+    def __repr__(self):
+        return '<{} "{}">'.format(self.__class__.__name__, self)
+
+    def __hash__(self):
+        return hash((self.name, self.kind, self.annotation, self.default))
+
+    def __eq__(self, other):
+        if self is other:
             return True
+        if not isinstance(other, Parameter):
+            return NotImplemented
+        return (self._name == other._name and
+                self._kind == other._kind and
+                self._default == other._default and
+                self._annotation == other._annotation)
 
-    return False
+
+class BoundArguments:
+    """Result of `Signature.bind` call.  Holds the mapping of arguments
+    to the function's parameters.
+
+    Has the following public attributes:
+
+    * arguments : dict
+        An ordered mutable mapping of parameters' names to arguments' values.
+        Does not contain arguments' default values.
+    * signature : Signature
+        The Signature object that created this instance.
+    * args : tuple
+        Tuple of positional arguments values.
+    * kwargs : dict
+        Dict of keyword arguments values.
+    """
+
+    __slots__ = ('arguments', '_signature', '__weakref__')
+
+    def __init__(self, signature, arguments):
+        self.arguments = arguments
+        self._signature = signature
+
+    @property
+    def signature(self):
+        return self._signature
+
+    @property
+    def args(self):
+        args = []
+        for param_name, param in self._signature.parameters.items():
+            if param.kind in (_VAR_KEYWORD, _KEYWORD_ONLY):
+                break
+
+            try:
+                arg = self.arguments[param_name]
+            except KeyError:
+                # We're done here. Other arguments
+                # will be mapped in 'BoundArguments.kwargs'
+                break
+            else:
+                if param.kind == _VAR_POSITIONAL:
+                    # *args
+                    args.extend(arg)
+                else:
+                    # plain argument
+                    args.append(arg)
+
+        return tuple(args)
+
+    @property
+    def kwargs(self):
+        kwargs = {}
+        kwargs_started = False
+        for param_name, param in self._signature.parameters.items():
+            if not kwargs_started:
+                if param.kind in (_VAR_KEYWORD, _KEYWORD_ONLY):
+                    kwargs_started = True
+                else:
+                    if param_name not in self.arguments:
+                        kwargs_started = True
+                        continue
+
+            if not kwargs_started:
+                continue
+
+            try:
+                arg = self.arguments[param_name]
+            except KeyError:
+                pass
+            else:
+                if param.kind == _VAR_KEYWORD:
+                    # **kwargs
+                    kwargs.update(arg)
+                else:
+                    # plain keyword argument
+                    kwargs[param_name] = arg
+
+        return kwargs
+
+    def apply_defaults(self):
+        """Set default values for missing arguments.
+
+        For variable-positional arguments (*args) the default is an
+        empty tuple.
+
+        For variable-keyword arguments (**kwargs) the default is an
+        empty dict.
+        """
+        arguments = self.arguments
+        new_arguments = []
+        for name, param in self._signature.parameters.items():
+            try:
+                new_arguments.append((name, arguments[name]))
+            except KeyError:
+                if param.default is not _empty:
+                    val = param.default
+                elif param.kind is _VAR_POSITIONAL:
+                    val = ()
+                elif param.kind is _VAR_KEYWORD:
+                    val = {}
+                else:
+                    # This BoundArguments was likely produced by
+                    # Signature.bind_partial().
+                    continue
+                new_arguments.append((name, val))
+        self.arguments = dict(new_arguments)
+
+    def __eq__(self, other):
+        if self is other:
+            return True
+        if not isinstance(other, BoundArguments):
+            return NotImplemented
+        return (self.signature == other.signature and
+                self.arguments == other.arguments)
+
+    def __setstate__(self, state):
+        self._signature = state['_signature']
+        self.arguments = state['arguments']
+
+    def __getstate__(self):
+        return {'_signature': self._signature, 'arguments': self.arguments}
+
+    def __repr__(self):
+        args = []
+        for arg, value in self.arguments.items():
+            args.append('{}={!r}'.format(arg, value))
+        return '<{} ({})>'.format(self.__class__.__name__, ', '.join(args))
 
 
 def can_accept_exactly_one_argument(callable_thing):
     """ Checks that a callable can accept exactly one argument
         using introspection.
     """
-    if inspect.ismethod(callable_thing):  # bound method
+    if ismethod(callable_thing):  # bound method
         f = callable_thing.__func__
         args = (callable_thing.__self__, 'test',)
     else:
-        if not inspect.isfunction(callable_thing):
+        if not isfunction(callable_thing):
             f = callable_thing.__call__
         else:
             f = callable_thing
@@ -46,23 +967,26 @@ def can_accept_exactly_one_argument(callable_thing):
         return True, None
 
 
-
 def get_f_from_callable(callable_thing):
-    if inspect.ismethod(callable_thing):  # bound method
+    if ismethod(callable_thing):  # bound method
         f = callable_thing.__func__
         # args = (callable_thing.__self__, 'test',)
     else:
-        if not inspect.isfunction(callable_thing):
+        if not isfunction(callable_thing):
             f = callable_thing.__call__
         else:
             f = callable_thing
             # args = ('test',)
     return f
 
+
 def get_callable_fullargspec(callable_thing):
+    f: Callable
+    spec: FullArgSpec
     f = get_f_from_callable(callable_thing)
     spec = getfullargspec(f)
     return spec
+
 
 def can_accept_at_least_one_argument(callable_thing):
     """ 
@@ -95,7 +1019,6 @@ def can_accept_self_plus_one_argument(callable_thing):
     if len(spec.args) == 0 or spec.args[0] != 'self':
         return False
 
-    # TODO: redo better
     f = get_f_from_callable(callable_thing)
     try:
         getcallargs(f, 'self', 'value')
@@ -108,6 +1031,7 @@ def can_accept_self_plus_one_argument(callable_thing):
 class InvalidArgs(Exception):
     pass
 
+
 def check_callable_accepts_these_arguments(callable_thing, args, kwargs):
     """ Checks that a callable can accept the args and kwargs. 
     
@@ -115,15 +1039,9 @@ def check_callable_accepts_these_arguments(callable_thing, args, kwargs):
     """
     f = get_f_from_callable(callable_thing)
 
-    # TODO: more cleanly
     try:
-        bound = getcallargs(f, *args, **kwargs)
-        # print('bound: %r ' % bound)
-    except (TypeError, ValueError) as e:  # @UnusedVariable
-        # print('no!: %s' % e)
+        getcallargs(f, *args, **kwargs)
+    except Exception as e:
         raise InvalidArgs('%s does not accept %s, %s: %s' % (f, args, kwargs, e))
-        # return False
     else:
         return True
-
-    return False

--- a/src/contracts/interface.py
+++ b/src/contracts/interface.py
@@ -20,7 +20,7 @@ class Where(object):
     """
 
     def __init__(self, string, character, character_end=None):
-        from contracts.utils import raise_desc
+        from ..contracts.utils import raise_desc
         if not isinstance(string, six.string_types):
             msg = 'I expect the string to be a str, not %r' % string
             raise ValueError(msg)
@@ -63,7 +63,7 @@ class Where(object):
 
     def get_substring(self):
         """ Returns the substring to which we refer. Raises error if character_end is None """
-        from contracts.utils import raise_desc
+        from ..contracts.utils import raise_desc
 
         if self.character_end is None:
             msg = 'Character end is None'
@@ -225,7 +225,7 @@ def location(line, col, s):
 
 
 def add_prefix(s, prefix):
-    from contracts import check_isinstance
+    from ..contracts import check_isinstance
     check_isinstance(s, six.string_types)
     check_isinstance(prefix, six.string_types)
     result = ""
@@ -465,7 +465,7 @@ class Contract(with_metaclass(ABCMeta, object)):
 
             Example:
 
-            >>> from contracts import parse
+            >>> from ..contracts import parse
             >>> contract = parse('list[N]')
             >>> contract.__repr__()
             "List(BindVariable('N',int),None)"
@@ -473,7 +473,7 @@ class Contract(with_metaclass(ABCMeta, object)):
             All the symbols you need to eval() the expression are in
             :py:mod:`contracts.library`.
 
-            >>> from contracts.library import *
+            >>> from ..contracts.library import *
             >>> contract == eval("%r"%contract)
             True
 
@@ -489,7 +489,7 @@ class Contract(with_metaclass(ABCMeta, object)):
 
             Example:
 
-            >>> from contracts import parse
+            >>> from ..contracts import parse
             >>> spec = 'list[N]'
             >>> contract = parse(spec)
             >>> contract
@@ -505,7 +505,7 @@ class Contract(with_metaclass(ABCMeta, object)):
 
             Example with extra parenthesis and whitespace:
 
-            >>> from contracts import parse
+            >>> from ..contracts import parse
             >>> verbose_spec = 'list[((N))]( int, > 0)'
             >>> contract = parse(verbose_spec)
             >>> str(contract)

--- a/src/contracts/interface.py
+++ b/src/contracts/interface.py
@@ -1,8 +1,7 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=True, initializedcheck=False
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import sys
 from abc import ABCMeta, abstractmethod
-
 from .metaclass import with_metaclass
 
 
@@ -20,8 +19,8 @@ class Where(object):
     """
 
     def __init__(self, string, character, character_end=None):
-        from ..contracts.utils import raise_desc
-        if not isinstance(string, six.string_types):
+        from Aspidites._vendor.contracts.utils import raise_desc
+        if not isinstance(string, basestring):
             msg = 'I expect the string to be a str, not %r' % string
             raise ValueError(msg)
 
@@ -63,7 +62,7 @@ class Where(object):
 
     def get_substring(self):
         """ Returns the substring to which we refer. Raises error if character_end is None """
-        from ..contracts.utils import raise_desc
+        from Aspidites._vendor.contracts.utils import raise_desc
 
         if self.character_end is None:
             msg = 'Character end is None'
@@ -155,24 +154,20 @@ def format_where(w, context_before=3, mark=None, arrow=True,
 
 def printable_length_where(w):
     """ Returns the printable length of the substring """
-    if sys.version_info[0] >= 3:  # pragma: no cover
-        stype = str
-    else:
-        stype = unicode
     sub = w.string[w.character:w.character_end]
     # return len(stype(sub, 'utf-8'))
     # I am not really sure this is what we want
-    return len(stype(sub))
+    return len(str(sub))
 
 
-import six
+from Aspidites._vendor._compat import basestring
 
 
 def line_and_col(loc, strg):
     """Returns (line, col), both 0 based."""
     from .utils import check_isinstance
     check_isinstance(loc, int)
-    check_isinstance(strg, six.string_types)
+    check_isinstance(strg, basestring)
     # first find the line 
     lines = strg.split('\n')
 
@@ -216,7 +211,7 @@ def location(line, col, s):
     from .utils import check_isinstance
     check_isinstance(line, int)
     check_isinstance(col, int)
-    check_isinstance(s, six.string_types)
+    check_isinstance(s, basestring)
 
     lines = s.split('\n')
     previous_lines = sum(len(l) + len('\n') for l in lines[:line])
@@ -225,9 +220,9 @@ def location(line, col, s):
 
 
 def add_prefix(s, prefix):
-    from ..contracts import check_isinstance
-    check_isinstance(s, six.string_types)
-    check_isinstance(prefix, six.string_types)
+    from Aspidites._vendor.contracts import check_isinstance
+    check_isinstance(s, basestring)
+    check_isinstance(prefix, basestring)
     result = ""
     for l in s.split('\n'):
         result += prefix + l + '\n'
@@ -296,7 +291,7 @@ class ContractNotRespected(ContractException):
         Exception.__init__(self, contract, error, value, context)
         assert isinstance(contract, Contract), contract
         assert isinstance(context, dict), context
-        assert isinstance(error, six.string_types), error
+        assert isinstance(error, basestring), error
 
         self.contract = contract
         self.error = error
@@ -312,7 +307,8 @@ class ContractNotRespected(ContractException):
 
             # don't display these two if are not used
             for x in ['args', 'kwargs']:
-                if x in keys and not context[x]: keys.remove(x)
+                if x in keys and not context[x]:
+                    keys.remove(x)
 
             try:
                 varss = ['- %s: %s' % (k, describe_value(context[k], clip=70))
@@ -333,7 +329,7 @@ class ContractNotRespected(ContractException):
 
         context0 = self.stack[0][1]
 
-        if context0:
+        if tuple(context0.keys()) == ("",):  # test for an empty or empty-like dict
             msg += ('\nVariables bound in inner context:\n%s'
                     % context_to_string(context0))
 
@@ -363,6 +359,9 @@ class RValue(with_metaclass(ABCMeta, object)):
         return (self.__class__ == other.__class__ and
                 self.__repr__() == other.__repr__())
 
+    def __hash__(self):
+        return hash(self.__repr__())
+
     @abstractmethod
     def __repr__(self):
         """ Same constraints as :py:func:`Contract.__repr__()`. """
@@ -384,10 +383,13 @@ def eval_in_context(context, value, contract):
 
 class Contract(with_metaclass(ABCMeta, object)):
 
+    __slots__ = ('__contract__', 'where')
+
     def __init__(self, where):
         assert ((where is None) or
                 (isinstance(where, Where), 'Wrong type %s' % where))
         self.where = where
+        self.__contract__ = True
         self.enable()
 
     def enable(self):
@@ -465,7 +467,7 @@ class Contract(with_metaclass(ABCMeta, object)):
 
             Example:
 
-            >>> from ..contracts import parse
+            >>> from contracts import parse
             >>> contract = parse('list[N]')
             >>> contract.__repr__()
             "List(BindVariable('N',int),None)"
@@ -473,7 +475,7 @@ class Contract(with_metaclass(ABCMeta, object)):
             All the symbols you need to eval() the expression are in
             :py:mod:`contracts.library`.
 
-            >>> from ..contracts.library import *
+            >>> from contracts.library import *
             >>> contract == eval("%r"%contract)
             True
 
@@ -489,7 +491,7 @@ class Contract(with_metaclass(ABCMeta, object)):
 
             Example:
 
-            >>> from ..contracts import parse
+            >>> from contracts import parse
             >>> spec = 'list[N]'
             >>> contract = parse(spec)
             >>> contract
@@ -505,7 +507,7 @@ class Contract(with_metaclass(ABCMeta, object)):
 
             Example with extra parenthesis and whitespace:
 
-            >>> from ..contracts import parse
+            >>> from contracts import parse
             >>> verbose_spec = 'list[((N))]( int, > 0)'
             >>> contract = parse(verbose_spec)
             >>> str(contract)
@@ -536,7 +538,7 @@ class Contract(with_metaclass(ABCMeta, object)):
 
 
 inPy2 = sys.version_info[0] == 2
-if inPy2:
+if inPy2:  # pragma: no cover
     from types import ClassType
 
 
@@ -549,16 +551,13 @@ def clipped_repr(x, clip):
     return s
 
 
-# TODO: add checks for these functions
-
-
 def remove_newlines(s):
     return s.replace('\n', ' ')
 
 
 def describe_type(x):
     """ Returns a friendly description of the type of x. """
-    if inPy2 and isinstance(x, ClassType):
+    if inPy2 and isinstance(x, ClassType):  # pragma: no cover
         class_name = '(old-style class) %s' % x
     else:
         if hasattr(x, '__class__'):
@@ -590,7 +589,7 @@ def describe_value(x, clip=80):
         return remove_newlines(final)
 
 
-def describe_value_multiline(x):
+def describe_value_multiline(x):  # pragma: no cover
     """ Describes an object, for use in the error messages. """
     if hasattr(x, 'shape') and hasattr(x, 'dtype'):
         # XXX this fails for bs4, Tag
@@ -602,7 +601,7 @@ def describe_value_multiline(x):
         else:
             return x.__repr__()
     else:
-        if isinstance(x, six.string_types):
+        if isinstance(x, basestring):
             if x == '': return "''"
             return x
         # XXX: this does not represent strings
@@ -615,7 +614,7 @@ def describe_value_multiline(x):
         #                 return x.__repr__()
         else:
             class_name = describe_type(x)
-            # TODO: add all types
+            # TODO: add all types to describe_value_multiline
             desc = 'Instance of %s.' % class_name
             try:
                 # This fails for classes

--- a/src/contracts/library/arithmetic.py
+++ b/src/contracts/library/arithmetic.py
@@ -1,6 +1,7 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from functools import reduce
 
-import six
+from Aspidites._vendor._compat import basestring
 
 from ..interface import RValue
 from ..syntax import isnumber, W
@@ -63,7 +64,7 @@ class Binary(RValue):
         exprs = [l.pop(0)]
         while l:
             glyph = l.pop(0)
-            assert isinstance(glyph, six.string_types)
+            assert isinstance(glyph, basestring)
             expr = l.pop(0)
             assert isinstance(expr, RValue)
             exprs.append(expr)
@@ -107,7 +108,7 @@ class Unary(RValue):
     def parse_action(s, loc, tokens):
         where = W(s, loc)
         glyph = tokens[0][0]
-        assert isinstance(glyph, six.string_types)
+        assert isinstance(glyph, basestring)
         expr = tokens[0][1]
         assert isinstance(expr, RValue)
         return Unary(glyph, expr, where=where)

--- a/src/contracts/library/array.py
+++ b/src/contracts/library/array.py
@@ -1,3 +1,4 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from ..interface import Contract, ContractNotRespected, describe_type
 from ..pyparsing_utils import myOperatorPrecedence
 from ..syntax import (add_contract, W, contract_expression, O, S, rvalue,
@@ -9,7 +10,7 @@ from .compositions import And, OR
 from .suggester import create_suggester
 from numpy import ndarray, dtype
 import numpy
-from pyparsing import infixNotation as operatorPrecedence, Or
+from Aspidites._vendor.pyparsing import infixNotation as operatorPrecedence, Or
 
 
 class Array(Contract):
@@ -71,7 +72,7 @@ class ShapeContract(Contract):
         expected = len(self.dimensions)
         ndim = len(value)
 
-        if ndim < expected:  # TODO: write clearer message
+        if ndim < expected:
             error = 'Expected %d dimensions, got %d.' % (expected, ndim)
             raise ContractNotRespected(contract=self, error=error,
                                        value=value, context=context)

--- a/src/contracts/library/array_ops.py
+++ b/src/contracts/library/array_ops.py
@@ -1,3 +1,4 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from abc import abstractmethod
 
 import numpy as np
@@ -222,7 +223,7 @@ class DType(ArrayElementsTest):
 
 
 np_types = {
-    'np_int': np.int,  # Platform integer (normally either int32 or int64)
+    'np_int': np.int_,  # Platform integer (normally either int32 or int64)
     'np_int8': np.int8,  # Byte (-128 to 127)
     'np_int16': np.int16,  # Integer (-32768 to 32767)
     'np_int32': np.int32,  # Integer (-2147483648 to 2147483647)
@@ -231,11 +232,11 @@ np_types = {
     'np_uint16': np.uint16,  # Unsigned integer (0 to 65535)
     'np_uint32': np.uint32,  # Unsigned integer (0 to 4294967295)
     'np_uint64': np.uint64,  # Unsigned integer (0 to 18446744073709551615)
-    'np_float': np.float,  # Shorthand for float64.
+    'np_float': np.float_,  # Shorthand for float64.
     'np_float16': np.float16,  # Half precision float: sign bit, 5 bits exponent, 10 bits mantissa
     'np_float32': np.float32,  # Single precision float: sign bit, 8 bits exponent, 23 bits mantissa
     'np_float64': np.float64,  # Double precision float: sign bit, 11 bits exponent, 52 bits mantissa
-    'np_complex': np.complex,  # Shorthand for complex128.
+    'np_complex': np.complex_,  # Shorthand for complex128.
     'np_complex64': np.complex64,  # Complex number, represented by two 32-bit floats (real and imaginary components)
     'np_complex128': np.complex128}
 

--- a/src/contracts/library/attributes.py
+++ b/src/contracts/library/attributes.py
@@ -1,6 +1,7 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from ..interface import Contract, ContractNotRespected
 from ..syntax import W, contract_expression, add_contract, add_keyword, Keyword
-from pyparsing import (Dict, delimitedList, Group, alphanums, Suppress, Literal,
+from Aspidites._vendor.pyparsing import (Dict, delimitedList, Group, alphanums, Suppress, Literal,
     Word)
 
 

--- a/src/contracts/library/collection.py
+++ b/src/contracts/library/collection.py
@@ -1,3 +1,5 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
+
 import collections
 
 from ..interface import Contract, ContractNotRespected
@@ -16,7 +18,7 @@ class Collection(Contract):
         try:
             # latest python 3.6+
             self.__collection_types = collections.abc.Collection
-        except:
+        except:  # pragma: no cover
             try:
                 # older python 3
                 self.__collection_types = collections.Collection

--- a/src/contracts/library/comparison.py
+++ b/src/contracts/library/comparison.py
@@ -1,6 +1,8 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
+
 import math
 
-from pyparsing import Or
+from Aspidites._vendor.pyparsing import Or
 
 from ..interface import Contract, ContractNotRespected, RValue, eval_in_context
 from ..syntax import W, add_contract, O, Literal, isnumber, rvalue

--- a/src/contracts/library/compositions.py
+++ b/src/contracts/library/compositions.py
@@ -1,3 +1,5 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
+
 from ..interface import Contract, ContractNotRespected, add_prefix
 from ..pyparsing_utils import myOperatorPrecedence
 from ..syntax import ParsingTmp, W, opAssoc, simple_contract
@@ -79,18 +81,19 @@ class OR(Logical, Contract):
             raise ContractNotRespected(contract=self, error=msg,
                         value=value, context=context)
 
-
-
     def _format_exceptions(self, exceptions):
         msg = ('Could not satisfy any of the %d clauses in %s.'
                % (len(self.clauses), self))
 
         for i, ex in enumerate(exceptions):
             c, e = ex
-            msg += '\n ---- Clause #%d:   %s\n' % (i + 1, c)
+            if i + 1 > 1:
+                msg += '\n ├┄┄┄ Clause #%d:   %s\n' % (i + 1, c)
+            else:
+                msg += '\n ┬┄┄┄┄ Clause #%d:   %s\n' % (i + 1, c)
             msg += add_prefix('%s' % e, ' | ')
 
-        msg += '\n ------- (end clauses) -------'
+        msg += '\n ╰┄┄┄┄┄┄ (end clauses) ┄┄┄┄┄┄'
         return msg
 
     def __repr__(self):

--- a/src/contracts/library/datetime_tz.py
+++ b/src/contracts/library/datetime_tz.py
@@ -1,3 +1,5 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
+
 import datetime
 
 from ..interface import Contract, ContractNotRespected, describe_type

--- a/src/contracts/library/dicts.py
+++ b/src/contracts/library/dicts.py
@@ -1,3 +1,5 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
+
 from ..interface import Contract, ContractNotRespected
 from ..syntax import (W, contract_expression, O, S, add_contract, add_keyword,
     Keyword)

--- a/src/contracts/library/dummy.py
+++ b/src/contracts/library/dummy.py
@@ -1,3 +1,4 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from ..interface import Contract, ContractNotRespected
 from ..syntax import add_contract, W, Literal
 

--- a/src/contracts/library/extensions.py
+++ b/src/contracts/library/extensions.py
@@ -60,7 +60,7 @@ class Extension(Contract):
         if not identifier in Extension.registrar:
             raise ParseException('Unknown extension contract %r' % identifier)
         
-        # from contracts.library.separate_context import SeparateContext
+        # from ..contracts.library.separate_context import SeparateContext
         
         contract_ext = Extension.registrar[identifier]
         
@@ -68,7 +68,7 @@ class Extension(Contract):
             callable_thing = contract_ext.callable 
          
             test_args = ('value',) + args
-            from contracts.inspection import check_callable_accepts_these_arguments, InvalidArgs
+            from ..contracts.inspection import check_callable_accepts_these_arguments, InvalidArgs
          
             try:
                 check_callable_accepts_these_arguments(callable_thing, test_args, kwargs)

--- a/src/contracts/library/files.py
+++ b/src/contracts/library/files.py
@@ -1,4 +1,4 @@
-# TODO: handle file mode?
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 
 import io
 import sys
@@ -6,11 +6,12 @@ import sys
 from ..interface import Contract, ContractNotRespected
 from ..syntax import (add_contract, add_keyword, Keyword, W)
 
-inPy2 = sys.version_info[0] == 2
-if inPy2:
-    file_type = (file, io.IOBase)
-else:
-    file_type = io.IOBase
+# inPy2 = sys.version_info[0] == 2
+# if inPy2:  # pragma: no cover
+#     file_type = (file, io.IOBase)
+# else:
+file_type = io.IOBase
+
 
 class File(Contract):
 

--- a/src/contracts/library/isinstance_imp.py
+++ b/src/contracts/library/isinstance_imp.py
@@ -1,6 +1,7 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from ..interface import Contract, ContractNotRespected
-from ..contracts.syntax import W, S, Keyword, add_contract, add_keyword
-from pyparsing import alphanums, Word
+from Aspidites._vendor.contracts.syntax import W, S, Keyword, add_contract, add_keyword
+from Aspidites._vendor.pyparsing import alphanums, Word
 
 __all__ = ['IsInstance', 'isinstance_contract']
 

--- a/src/contracts/library/isinstance_imp.py
+++ b/src/contracts/library/isinstance_imp.py
@@ -1,5 +1,5 @@
 from ..interface import Contract, ContractNotRespected
-from contracts.syntax import W, S, Keyword, add_contract, add_keyword
+from ..contracts.syntax import W, S, Keyword, add_contract, add_keyword
 from pyparsing import alphanums, Word
 
 __all__ = ['IsInstance', 'isinstance_contract']

--- a/src/contracts/library/lists.py
+++ b/src/contracts/library/lists.py
@@ -1,3 +1,4 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from ..interface import Contract, ContractNotRespected
 from ..syntax import (add_contract, W, contract_expression, O, S, add_keyword,
     Keyword)

--- a/src/contracts/library/map.py
+++ b/src/contracts/library/map.py
@@ -1,7 +1,8 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from ..interface import Contract, ContractNotRespected
 from ..syntax import (W, contract_expression, O, S, add_contract, add_keyword,
     Keyword)
-import collections
+import collections.abc as collections
 
 
 class Map(Contract):

--- a/src/contracts/library/miscellaneous_aliases.py
+++ b/src/contracts/library/miscellaneous_aliases.py
@@ -11,8 +11,8 @@ def ist(C):
 
 
 def m_new_contract(name, f):
-    from contracts.library.extensions import CheckCallable
-    from contracts.library.extensions import Extension
+    from ..contracts.library.extensions import CheckCallable
+    from ..contracts.library.extensions import Extension
     Extension.registrar[name] = CheckCallable(f)
     
 

--- a/src/contracts/library/miscellaneous_aliases.py
+++ b/src/contracts/library/miscellaneous_aliases.py
@@ -1,5 +1,5 @@
-import collections
-
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
+import collections.abc as collections
 
 
 def ist(C):
@@ -11,17 +11,16 @@ def ist(C):
 
 
 def m_new_contract(name, f):
-    from ..contracts.library.extensions import CheckCallable
-    from ..contracts.library.extensions import Extension
+    from Aspidites._vendor.contracts.library.extensions import CheckCallable
+    from Aspidites._vendor.contracts.library.extensions import Extension
     Extension.registrar[name] = CheckCallable(f)
     
 
 m_new_contract('Container', ist(collections.Container))
-# todo: Iterable(x)
 m_new_contract('Iterable', ist(collections.Iterable))
 
 m_new_contract('Hashable', ist(collections.Hashable))
-
+m_new_contract('Generator', ist(collections.Generator))
 
 
 m_new_contract('Iterator', ist(collections.Iterator))
@@ -42,5 +41,8 @@ m_new_contract('MutableMapping', ist(collections.MutableMapping))
 def is_None(x): 
     return x is None
 
+
+m_new_contract('procedure', is_None)
+m_new_contract('coroutine', ist(collections.Generator))
 m_new_contract('None', is_None)
 m_new_contract('NoneType', is_None)

--- a/src/contracts/library/scoped_variables.py
+++ b/src/contracts/library/scoped_variables.py
@@ -3,7 +3,7 @@ from ..syntax import S, W
 from ..utils import ignore_typeerror
 from pyparsing import Word, alphanums
 import inspect
-from contracts.library.types_misc import CheckType
+from ..contracts.library.types_misc import CheckType
 
 
 def _lookup_from_calling_scope(token):
@@ -94,9 +94,9 @@ def scoped_parse_action(s, loc, tokens):
     where = W(s, loc)
     val = _lookup_from_calling_scope(tokens[0])
 
-    from contracts.library.simple_values import SimpleRValue
+    from ..contracts.library.simple_values import SimpleRValue
 
-    from contracts.inspection import can_be_used_as_a_type
+    from ..contracts.inspection import can_be_used_as_a_type
 
     if can_be_used_as_a_type(val):
         return CheckType(val)

--- a/src/contracts/library/scoped_variables.py
+++ b/src/contracts/library/scoped_variables.py
@@ -1,9 +1,10 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from ..interface import ExternalScopedVariableNotFound
 from ..syntax import S, W
 from ..utils import ignore_typeerror
-from pyparsing import Word, alphanums
+from Aspidites._vendor.pyparsing import Word, alphanums
 import inspect
-from ..contracts.library.types_misc import CheckType
+from Aspidites._vendor.contracts.library.types_misc import CheckType
 
 
 def _lookup_from_calling_scope(token):
@@ -16,14 +17,15 @@ def _lookup_from_calling_scope(token):
     #
     # XXX Check if there are other places where a spec might be defined
     from .. import decorate, parse, check, fail
+    from ..inspection import getouterframes, currentframe
 
     def _code(f):
-        try:  # py2
+        try:  # pragma: no cover
             return f.func_code
         except AttributeError:  # py3
             return f.__code__
 
-    frames = inspect.getouterframes(inspect.currentframe())
+    frames = getouterframes(currentframe())
     frames = [f[0] for f in frames[::-1]]
     fcodes = [f.f_code for f in frames]
 
@@ -94,11 +96,9 @@ def scoped_parse_action(s, loc, tokens):
     where = W(s, loc)
     val = _lookup_from_calling_scope(tokens[0])
 
-    from ..contracts.library.simple_values import SimpleRValue
+    from Aspidites._vendor.contracts.library.simple_values import SimpleRValue
 
-    from ..contracts.inspection import can_be_used_as_a_type
-
-    if can_be_used_as_a_type(val):
+    if isinstance(val, type):
         return CheckType(val)
     else:
         return SimpleRValue(value=val, where=where, representation=s)

--- a/src/contracts/library/separate_context.py
+++ b/src/contracts/library/separate_context.py
@@ -1,3 +1,4 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from ..interface import Contract
 from ..syntax import add_contract, W, contract_expression, Literal, Group
 

--- a/src/contracts/library/seq.py
+++ b/src/contracts/library/seq.py
@@ -1,13 +1,14 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from ..interface import Contract, ContractNotRespected
 from ..syntax import (add_contract, W, contract_expression, O, S, add_keyword,
     Keyword)
-import collections
+import collections.abc as collections
 from past.builtins import xrange
 
 try:
     import numpy
     has_numpy = True
-except:
+except ImportError:
     has_numpy = False
 
 
@@ -21,7 +22,6 @@ class Seq(Contract):
 
     def check_contract(self, context, value, silent):
         if has_numpy and isinstance(value, numpy.ndarray):
-            # TODO: check basic datatypes
             # use value.size and value.flat for iteration
             if self.length_contract is not None:
                 self.length_contract._check_contract(context, value.size, silent)

--- a/src/contracts/library/sets.py
+++ b/src/contracts/library/sets.py
@@ -1,7 +1,8 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from ..interface import Contract, ContractNotRespected, describe_type
 from ..syntax import (Keyword, O, S, W, add_contract, add_keyword,
     contract_expression)
-import collections
+import collections.abc as collections
 
 
 class ASet(Contract):

--- a/src/contracts/library/simple_values.py
+++ b/src/contracts/library/simple_values.py
@@ -29,7 +29,7 @@ class EqualTo(Contract):
     def parse_action(s, loc, tokens):
         where = W(s, loc)
         rvalue = tokens[0]
-        from contracts.library.types_misc import CheckType
+        from ..contracts.library.types_misc import CheckType
         if isinstance(rvalue, CheckType):
             return rvalue
         else:

--- a/src/contracts/library/simple_values.py
+++ b/src/contracts/library/simple_values.py
@@ -1,4 +1,5 @@
-import six
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
+from Aspidites._vendor._compat import basestring
 
 from ..interface import Contract, ContractNotRespected, RValue
 from ..syntax import W
@@ -29,7 +30,7 @@ class EqualTo(Contract):
     def parse_action(s, loc, tokens):
         where = W(s, loc)
         rvalue = tokens[0]
-        from ..contracts.library.types_misc import CheckType
+        from Aspidites._vendor.contracts.library.types_misc import CheckType
         if isinstance(rvalue, CheckType):
             return rvalue
         else:
@@ -39,7 +40,7 @@ class EqualTo(Contract):
 
 class SimpleRValue(RValue):
     def __init__(self, value, representation=None, where=None):
-        assert representation is None or isinstance(representation, six.string_types)
+        assert representation is None or isinstance(representation, basestring)
         self.value = value
         self.where = where
         self.representation = representation

--- a/src/contracts/library/strings.py
+++ b/src/contracts/library/strings.py
@@ -1,7 +1,7 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 import sys
 
-import six
-
+from ..._compat import unicode
 from ..interface import Contract, ContractNotRespected
 from ..syntax import (add_contract, W, contract_expression, O, add_keyword,
     Keyword, Literal)
@@ -68,7 +68,7 @@ else:  # Python 2.x
 
 class UnicodeString(StringBase):
     KEYWORDS = ['unicode']
-    TYPE = six.text_type
+    TYPE = unicode
     DESCRIPTION = "a Unicode string"
 
 

--- a/src/contracts/library/suggester.py
+++ b/src/contracts/library/suggester.py
@@ -1,3 +1,4 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 import operator
 
 
@@ -14,6 +15,7 @@ def longest_match(a, b):
         if a[:i] == b[:i]:
             return i
     assert False  # pragma: no cover
+
 
 assert ('float64', 6) == find_longest_match('float6', ['float32', 'float64'])
 assert 2 == find_longest_match('fl6', ['float32', 'float64'])[1]
@@ -91,8 +93,6 @@ def create_suggester(get_options, get_message=default_message,
                 Keyword('attr') + attrs_spec
         '''
         assert not (identifier in options), msg
-
-        
         msg = get_message(identifier)
 
         if options:

--- a/src/contracts/library/tuple.py
+++ b/src/contracts/library/tuple.py
@@ -1,3 +1,4 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from ..interface import Contract, ContractNotRespected
 from ..syntax import(add_contract, W, contract_expression, O, S, ZeroOrMore,
                       Group, add_keyword, Keyword)

--- a/src/contracts/library/types_misc.py
+++ b/src/contracts/library/types_misc.py
@@ -1,4 +1,5 @@
-from ..interface import Contract, ContractNotRespected
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
+from ..interface import Contract, ContractNotRespected, describe_type
 from ..syntax import (W, add_contract, contract_expression, S, Keyword,
     add_keyword)
 from numbers import Number
@@ -7,8 +8,7 @@ from numbers import Number
 class CheckType(Contract):
 
     def __init__(self, types, type_string=None, where=None):
-        from ..main import can_be_used_as_a_type  # XXX: make it better
-        assert can_be_used_as_a_type(types)
+        assert isinstance(types, type)
         Contract.__init__(self, where)
         self.types = types
         if type_string is None:
@@ -18,7 +18,6 @@ class CheckType(Contract):
 
     def check_contract(self, context, value, silent):
         if not isinstance(value, self.types):
-            from ..contracts.interface import describe_type
             error = 'Expected type %r, got %s.' % (self.types.__name__,
                                                    describe_type(value))
             raise ContractNotRespected(contract=self, error=error,
@@ -52,7 +51,6 @@ add_keyword('Number')
 
 add_contract(Keyword('bool').setParseAction(CheckType.parse_action(bool)))
 add_keyword('bool')
-
 
 
 class Type(Contract):

--- a/src/contracts/library/types_misc.py
+++ b/src/contracts/library/types_misc.py
@@ -18,7 +18,7 @@ class CheckType(Contract):
 
     def check_contract(self, context, value, silent):
         if not isinstance(value, self.types):
-            from contracts.interface import describe_type
+            from ..contracts.interface import describe_type
             error = 'Expected type %r, got %s.' % (self.types.__name__,
                                                    describe_type(value))
             raise ContractNotRespected(contract=self, error=error,

--- a/src/contracts/library/variables.py
+++ b/src/contracts/library/variables.py
@@ -1,12 +1,14 @@
-import six
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
+from ...._vendor._compat import basestring
 
 from ..interface import Contract, ContractNotRespected, RValue, describe_value
 from ..syntax import (W, oneOf, FollowedBy, NotAny)
 
+
 class BindVariable(Contract):
 
     def __init__(self, variable, allowed_types, where=None):
-        assert isinstance(variable, six.string_types) and len(variable) == 1
+        assert isinstance(variable, basestring) and len(variable) == 1
         assert allowed_types, '%r' % allowed_types
         Contract.__init__(self, where)
         self.variable = variable
@@ -16,12 +18,7 @@ class BindVariable(Contract):
         if self.variable in context:
             expected = context[self.variable]
             if not (expected == value):
-                # TODO: add where it was bound
-                error = (
-                'Expected value for %r was: %s\n'
-                '        instead I received: %s' %
-                         (self.variable, describe_value(expected),
-                         describe_value(value)))
+                error = ('Expected value for %r was: %s\n        instead I received: %s' % (self.variable, describe_value(expected), describe_value(value)))
                 raise ContractNotRespected(contract=self, error=error,
                                            value=value, context=context)
 
@@ -58,7 +55,7 @@ class BindVariable(Contract):
 
 class VariableRef(RValue):
     def __init__(self, variable, where=None):
-        assert isinstance(variable, six.string_types)
+        assert isinstance(variable, basestring)
         self.where = where
         self.variable = variable
 

--- a/src/contracts/main_actual.py
+++ b/src/contracts/main_actual.py
@@ -1,4 +1,4 @@
-
+# cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 # class Extra:
 #     loading = False
 #
@@ -10,34 +10,208 @@
 #         # And after everything else is loaded, load the  utils
 #     else:
 #         print('already loading...')
-    
+from .syntax import ParseException
+from .library.extensions import CheckCallableWithSelf
+from .library import CheckCallable, Extension, SeparateContext, identifier_expression
+from .inspection import can_accept_self, can_accept_at_least_one_argument
+from .interface import Contract, ContractSyntaxError, Where, describe_value, ContractNotRespected
+from .syntax import contract_expression
+from .inspection import getfullargspec
+
+
+class Storage:
+    # Cache storage
+    string2contract = {}
+
+
+def _cacheable(string, c):
+    """ Returns whether the contract c defined by string string is cacheable. """
+    # XXX need a more general way of indicating
+    #     whether a contract is safely cacheable
+    return '$' not in string
+
+
+def get_annotations(function):
+    return getfullargspec(function).annotations
+
+
+def get_all_arg_names(function):
+    spec = getfullargspec(function)
+    possible = spec.args + [spec.varargs, spec.varkw] + spec.kwonlyargs
+    all_args = [x for x in possible if x]
+    return all_args
+
+
+def check_param_is_string(x):
+    if not isinstance(x, str):
+        msg = 'Expected a string, obtained %s' % type(x)
+        raise ValueError(msg)
+
+
+def new_contract_impl(identifier, condition):
+    from .main import parse_flexible_spec
+    # Be friendly
+    if not isinstance(identifier, str):
+        msg = 'I expect the identifier to be a string; received %s.' % describe_value(identifier)
+        raise ValueError(msg)
+
+    # Make sure it is not already an expression that we know.
+    # (exception: allow redundant definitions. To this purpose,
+    #   skip this test if the identifier is already known, and catch
+    #   later if the condition changed.)
+    if identifier in Extension.registrar:
+        # already known as identifier; check later if the condition
+        # remained the same.
+        pass
+    else:
+        # check it does not redefine list, tuple, etc.
+        try:
+            c = parse_contract_string_actual(identifier)
+            msg = ('Invalid identifier %r; it overwrites an already known '
+                   'expression. In fact, I can parse it as %s (%r).' %
+                   (identifier, c, c))
+            raise ValueError(msg)
+        except ContractSyntaxError:
+            pass
+
+    # Make sure it corresponds to our idea of identifier
+    try:
+        c = identifier_expression.parseString(identifier, parseAll=True)
+    except ParseException as e:
+        loc = e.loc
+        if loc >= len(identifier):
+            loc -= 1
+        where = Where(identifier, character=loc)  # line=e.lineno, column=e.col)
+        # msg = 'Error in parsing string: %s' % e
+        msg = ('The given identifier %r does not correspond to my idea '
+               'of what an identifier should look like;\n%s\n%s'
+               % (identifier, e, where))
+        raise ValueError(msg)
+
+    # Now let's check the condition
+    if isinstance(condition, str):
+        # We assume it is a condition that should parse cleanly
+        try:
+            # could call parse_flexible_spec as well here
+            bare_contract = parse_contract_string_actual(condition)
+        except ContractSyntaxError as e:
+            msg = ('The given condition %r does not parse cleanly: %s' %
+                   (condition, e))
+            raise ValueError(msg)
+    # Important: types are callable, so check this first.
+    elif hasattr(condition, '__weakrefoffset__'):
+        # parse_flexible_spec can take care of types
+        bare_contract = parse_flexible_spec(condition)
+    # Lastly, it should be a callable
+    elif hasattr(condition, '__call__'):
+        # Check that the signature is right
+        if can_accept_self(condition):
+            bare_contract = CheckCallableWithSelf(condition)
+        elif can_accept_at_least_one_argument(condition):
+            bare_contract = CheckCallable(condition)
+        else:
+            raise ValueError("The given callable %r should be able to accept "
+                             "at least one argument" % condition)
+    else:
+        raise ValueError('I need either a string or a callable for the '
+                         'condition; found %s.' % describe_value(condition))
+
+    # Separate the context if needed
+    if isinstance(bare_contract, (CheckCallable, CheckCallableWithSelf)):
+        contract = bare_contract
+    else:
+        contract = SeparateContext(bare_contract)
+
+    # It's okay if we define the same thing twice
+    if identifier in Extension.registrar:
+        old = Extension.registrar[identifier]
+        if not (contract == old):
+            msg = ('Tried to redefine %r with a definition that looks '
+                   'different to me.\n' % identifier)
+            msg += ' - old: %r\n' % old
+            msg += ' - new: %r\n' % contract
+            raise ValueError(msg)
+    else:
+        Extension.registrar[identifier] = contract
+
+    # Before, we check that we can parse it now
+    # - not anymore, because since there are possible args/kwargs,
+    # - it might be that the keyword alone is not a valid contract
+    # if False:
+    #     try:
+    #         c = parse_contract_string(identifier)
+    #         expected = Extension(identifier)
+    #         assert c == expected, \
+    #             'Expected %r, got %r.' % (c, expected)  # pragma: no cover
+    #     except ContractSyntaxError:  # pragma: no cover
+    #         #assert False, 'Cannot parse %r: %s' % (identifier, e)
+    #         raise
+
+    return contract
+
 
 def parse_contract_string_actual(string):
-    from .interface import (Contract, ContractDefinitionError, ContractSyntaxError,
-        Where)
-    from .main import Storage, _cacheable, check_param_is_string
-    from .syntax import ParseException, ParseFatalException, contract_expression
-
+    msg: str
+    where: Where
     check_param_is_string(string)
-
     if string in Storage.string2contract:
         return Storage.string2contract[string]
     try:
-        c = contract_expression.parseString(string,
-                                            parseAll=True)[0]
-        assert isinstance(c, Contract), 'Want Contract, not %r' % c
+        c = contract_expression.parseString(string, parseAll=True)[0]
+        assert hasattr(c, '__contract__'), 'Want Contract, not %r' % c
         if _cacheable(string, c):
             Storage.string2contract[string] = c
         return c
-    except ContractDefinitionError as e:
-        raise
-    except ParseException as e:
-        where = Where(string, character=e.loc)
+    except Exception as e:
         msg = '%s' % e
-        raise ContractSyntaxError(msg, where=where)
-    except ParseFatalException as e:
-        where = Where(string, character=e.loc)
-        msg = '%s' % e
-        raise ContractSyntaxError(msg, where=where)
+        if hasattr(e, 'loc'):  # ParseBaseException
+            where = Where(string, character=e.loc)
+            raise ContractSyntaxError(msg, where=where)
+        else:
+            raise  # ContractDefinitionError
 
 
+def check_contracts(contracts, values, context_variables=None):
+    """
+        Checks that the values respect the contract.
+        Not a public function -- no friendly messages.
+
+        :param contracts: List of contracts.
+        :type contracts:  ``list[N](str),N>0``
+
+        :param values: Values that should match the contracts.
+        :type values: ``list[N]``
+
+        :param context_variables: Initial context
+        :type context_variables: ``dict(str[1]: *)``
+
+        :return: a Context variable
+        :rtype: type(Context)
+
+        :raise: ContractSyntaxError
+        :raise: ContractNotRespected
+        :raise: ValueError
+    """
+    assert isinstance(contracts, list)
+    assert isinstance(contracts, list)
+    assert len(contracts) == len(values)
+
+    if context_variables is None:
+        context_variables = {}
+
+    for var in context_variables:
+        if not (isinstance(var, str) and len(var) == 1):  # XXX: isalpha
+            msg = ('Invalid name %r for a variable. '
+                   'I expect a string of length 1.' % var)
+            raise ValueError(msg)
+
+    C = []
+    for x in contracts:
+        assert isinstance(x, str)
+        C.append(parse_contract_string_actual(x))
+
+    context = context_variables.copy()
+    for i in range(len(contracts)):
+        C[i]._check_contract(context, values[i], silent=False)
+
+    return context

--- a/src/contracts/metaclass.py
+++ b/src/contracts/metaclass.py
@@ -54,7 +54,7 @@ class ContractsMeta(ABCMeta):
                                 # msg = 'inherit contracts for %s:%s() from %s' % (clsname, k, b.__name__)
                                 # print(msg)
                                 # TODO: check that the contracts are a subtype
-                                from contracts import ContractException
+                                from ..contracts import ContractException
                                 try:
                                     from .main import contracts_decorate
                                     f1 = contracts_decorate(f, **spec)

--- a/src/contracts/metaclass.py
+++ b/src/contracts/metaclass.py
@@ -1,3 +1,4 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from abc import ABCMeta
 from types import FunctionType
 import traceback
@@ -7,10 +8,11 @@ __all__ = ['ContractsMeta']
 
 
 def is_function_or_static(f):
-    is_normal_function = isinstance(f, FunctionType)
-    is_staticmethod = isinstance(f, staticmethod)
-    is_classmethod = isinstance(f, classmethod)
+    is_normal_function: bool = isinstance(f, FunctionType)
+    is_staticmethod: bool = isinstance(f, staticmethod)
+    is_classmethod: bool = isinstance(f, classmethod)
     return is_normal_function or is_staticmethod or is_classmethod
+
 
 class ContractsMeta(ABCMeta):
     """
@@ -53,8 +55,8 @@ class ContractsMeta(ABCMeta):
                                 spec = f0.__contracts__
                                 # msg = 'inherit contracts for %s:%s() from %s' % (clsname, k, b.__name__)
                                 # print(msg)
-                                # TODO: check that the contracts are a subtype
-                                from ..contracts import ContractException
+                                # TODO: check that the contracts are a subtype of ContractsMeta
+                                from Aspidites._vendor.contracts import ContractException
                                 try:
                                     from .main import contracts_decorate
                                     f1 = contracts_decorate(f, **spec)
@@ -80,6 +82,7 @@ class ContractsMeta(ABCMeta):
             else:
                 pass
                 # print(' -> No inheritance for %s' % this_function)
+
 
 # This function is taken from six.
 # https://bitbucket.org/gutworth/six

--- a/src/contracts/syntax.py
+++ b/src/contracts/syntax.py
@@ -1,36 +1,37 @@
+# cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 from numbers import Number
 import math
 
-
 # All the imports from pyparsing go here
-from pyparsing import (delimitedList, Forward, Literal,
-                       stringEnd, nums, Word, CaselessLiteral, Combine,
-                       Optional, Suppress, OneOrMore, ZeroOrMore, opAssoc,
-                       infixNotation as operatorPrecedence, oneOf, ParseException,
-                       ParserElement,
-                       alphas, alphanums, ParseFatalException,
-                       ParseSyntaxException, FollowedBy, NotAny, Or,
-                       MatchFirst, Keyword, Group, White, lineno, col)
+from typing import Any, List
 
+from types import ModuleType
+
+from pyparsing import (delimitedList, Forward, Literal,
+                                         stringEnd, nums, Word, CaselessLiteral, Combine,
+                                         Optional, Suppress, OneOrMore, ZeroOrMore, opAssoc,
+                                         infixNotation as operatorPrecedence, oneOf, ParseException,
+                                         ParserElement,
+                                         alphas, alphanums, ParseFatalException,
+                                         ParseSyntaxException, FollowedBy, NotAny, Or,
+                                         MatchFirst, Keyword, Group, White, lineno, col)
 
 # from .pyparsing_utils import myOperatorPrecedence
 
 
 # Enable memoization (much faster!)
-if True:
-    ParserElement.enablePackrat(cache_size_limit=None)
-else:
-    # Pyparsing 2.0
-    from pyparsing import infixNotation
-    myOperatorPrecendence = infixNotation
+ParserElement.enablePackrat(cache_size_limit=None)
+# else:
+#     # Pyparsing 2.0
+#     from pyparsing import infixNotation
+#     myOperatorPrecendence = infixNotation
 
 from .interface import Where
 
 
-class ParsingTmp():
-    # TODO: FIXME: decide on an order, if we do the opposite it doesn't work.
-    contract_types = []
-    keywords = []
+class ParsingTmp:
+    contract_types: List[Any] = []
+    keywords: List[Any] = []
 
 
 def add_contract(x):
@@ -46,8 +47,8 @@ def add_keyword(x):
     """
     ParsingTmp.keywords.append(x)
 
-W = Where
 
+W = Where
 
 O = Optional
 S = Suppress
@@ -64,21 +65,26 @@ floatnumber.setParseAction(lambda tokens: SimpleRValue(float(tokens[0])))
 pi = Keyword('pi').setParseAction(
     lambda tokens: SimpleRValue(math.pi, 'pi'))  # @UnusedVariable
 
+np_ = False
 
 try:
     import numpy
 except ImportError:
-    numpy = None
+    pass
+else:
+    np_ = True
+
 
 def isnumber(x):
     # These are scalar quantities that we can compare (=,>,>=, etc.)
     if isinstance(x, Number):
         return True
 
-    if numpy is not None and isinstance(x, numpy.number):
+    if np_ and isinstance(x, numpy.number):
         return True
 
     return False
+
 
 rvalue = Forward()
 rvalue.setName('rvalue')
@@ -94,11 +100,9 @@ from .library import (EqualTo, Unary, Binary, composite_contract,
                       int_variables_contract, int_variables_ref,
                       misc_variables_ref, SimpleRValue)
 
-
 number = pi | floatnumber | integer
 operand = number | int_variables_ref | misc_variables_ref | scoped_variables_ref
 operand.setName('r-value')
-
 
 op = operatorPrecedence
 # op  = myOperatorPrecedence
@@ -109,7 +113,6 @@ rvalue << op(operand, [
     ('+', 2, opAssoc.LEFT, Binary.parse_action),
     ('^', 2, opAssoc.LEFT, Binary.parse_action),
 ])
-
 
 # I want
 # - BindVariable to have precedence to EqualTo(VariableRef)

--- a/src/contracts/testing/array_extended_test.py
+++ b/src/contracts/testing/array_extended_test.py
@@ -6,7 +6,7 @@ else:
 
     import unittest
 
-    from contracts import decorate, new_contract, ContractNotRespected
+    from ...contracts import decorate, new_contract, ContractNotRespected
 
     new_contract('rgb', 'array[HxWx3],H>0,W>0')
     new_contract('rgba', 'array[HxWx4],H>0,W>0')

--- a/src/contracts/testing/friendliness_statistics.py
+++ b/src/contracts/testing/friendliness_statistics.py
@@ -1,6 +1,6 @@
-from contracts.test_registrar import (good_examples, semantic_fail_examples,
+from ...contracts.test_registrar import (good_examples, semantic_fail_examples,
                                       contract_fail_examples)
-from contracts import parse, ContractSyntaxError
+from ...contracts import parse, ContractSyntaxError
 
 
 def get_all_strings():

--- a/src/contracts/testing/library/__init__.py
+++ b/src/contracts/testing/library/__init__.py
@@ -1,4 +1,4 @@
-from contracts.test_registrar import syntax_fail, good, fail, semantic_fail
+from ....contracts.test_registrar import syntax_fail, good, fail, semantic_fail
 
 from . import dummy_tc
 from . import separate_context_tc

--- a/src/contracts/testing/library/array_tc.py
+++ b/src/contracts/testing/library/array_tc.py
@@ -2,7 +2,7 @@ from numpy import zeros, ones
 import numpy as np
 
 from . import syntax_fail, good, fail
-from contracts.library.array import np_int_dtypes, np_uint_dtypes, \
+from ....contracts.library.array import np_int_dtypes, np_uint_dtypes, \
     np_float_dtypes
 
 a_u8 = np.zeros((3, 4), dtype='uint8')

--- a/src/contracts/testing/library/extensions_tc.py
+++ b/src/contracts/testing/library/extensions_tc.py
@@ -1,5 +1,5 @@
-from contracts import new_contract
-from contracts.test_registrar import fail, good, syntax_fail
+from ....contracts import new_contract
+from ....contracts.test_registrar import fail, good, syntax_fail
 
 
 

--- a/src/contracts/testing/library/test_scoped_variables.py
+++ b/src/contracts/testing/library/test_scoped_variables.py
@@ -1,9 +1,9 @@
-from contracts import ContractException, check, contract, decorate, fail, parse
-from contracts.interface import (ContractNotRespected,
+from ....contracts import ContractException, check, contract, decorate, fail, parse
+from ....contracts.interface import (ContractNotRespected,
     ExternalScopedVariableNotFound)
-from contracts.library.simple_values import EqualTo
-from contracts.library.types_misc import CheckType
-from contracts.utils import check_isinstance
+from ....contracts.library.simple_values import EqualTo
+from ....contracts.library.types_misc import CheckType
+from ....contracts.utils import check_isinstance
 from nose.tools import raises
 
 

--- a/src/contracts/testing/test_class_contracts.py
+++ b/src/contracts/testing/test_class_contracts.py
@@ -1,4 +1,4 @@
-from contracts import contract, new_contract, ContractNotRespected
+from ...contracts import contract, new_contract, ContractNotRespected
 import unittest
 
 

--- a/src/contracts/testing/test_decorator.py
+++ b/src/contracts/testing/test_decorator.py
@@ -1,9 +1,9 @@
 import unittest
 
-from contracts import (decorate, contract,
+from ...contracts import (decorate, contract,
                 ContractException, ContractNotRespected)
 
-from contracts.interface import MissingContract
+from ...contracts.interface import MissingContract
 
 
 class DecoratorTests(unittest.TestCase):

--- a/src/contracts/testing/test_docstring_parsing.py
+++ b/src/contracts/testing/test_docstring_parsing.py
@@ -1,7 +1,7 @@
 import unittest
 
 from ..docstring_parsing import DocStringInfo, Arg, number_of_spaces
-from contracts.interface import add_prefix
+from ...contracts.interface import add_prefix
 
 
 examples = {"""

--- a/src/contracts/testing/test_idioms.py
+++ b/src/contracts/testing/test_idioms.py
@@ -1,6 +1,6 @@
 import unittest
 
-from contracts import (check, ContractNotRespected, Contract, parse,
+from ...contracts import (check, ContractNotRespected, Contract, parse,
                        check_multiple, ContractSyntaxError, fail)
 
 
@@ -81,7 +81,7 @@ class TestIdioms(unittest.TestCase):
                           'my message')
 
 #     def test_symbols(self):
-#         from contracts import contract_expression  # @UnusedImport
+#         from ...contracts import contract_expression  # @UnusedImport
         # TODO: type
 
     def test_equality_contract(self):

--- a/src/contracts/testing/test_meta.py
+++ b/src/contracts/testing/test_meta.py
@@ -3,9 +3,9 @@ import functools
 import nose
 import unittest
 
-from contracts import ContractNotRespected, contract, ContractsMeta
-from contracts import CannotDecorateClassmethods
-from contracts import with_metaclass
+from ...contracts import ContractNotRespected, contract, ContractsMeta
+from ...contracts import CannotDecorateClassmethods
+from ...contracts import with_metaclass
 
 def expected_failure(test):
     @functools.wraps(test)

--- a/src/contracts/testing/test_new_contract.py
+++ b/src/contracts/testing/test_new_contract.py
@@ -1,11 +1,11 @@
 import unittest
 
-from contracts import new_contract, check, Contract, contract
-from contracts.library.extensions import identifier_expression
+from ...contracts import new_contract, check, Contract, contract
+from ...contracts.library.extensions import identifier_expression
 
 from .utils import check_contracts_fail, check_contracts_ok
-from contracts.main import can_be_used_as_a_type, Storage
-from contracts.syntax import ParsingTmp
+from ...contracts.main import can_be_used_as_a_type, Storage
+from ...contracts.syntax import ParsingTmp
 
 # The different patterns
 
@@ -233,7 +233,7 @@ class TestNewContract(unittest.TestCase):
         @new_contract
         def even(x):
             return x % 2 == 0
-        from contracts import parse
+        from ...contracts import parse
         p = parse('even')
         p.check(2)
         p.check(4)
@@ -246,7 +246,7 @@ class TestNewContract(unittest.TestCase):
         def even2(x):
             return x % 2 == 0
 
-        from contracts import parse
+        from ...contracts import parse
         p = parse('even2')
         p.check(2)
         p.fail(3)
@@ -278,7 +278,7 @@ class TestNewContract(unittest.TestCase):
         assert can_be_used_as_a_type(NewStyleClass)
 
     def test_as_decorator_with_args(self):
-        from contracts import parse
+        from ...contracts import parse
 
         @new_contract
         def greater_than(value, thresh):
@@ -289,7 +289,7 @@ class TestNewContract(unittest.TestCase):
         p.fail(5)
 
     def test_as_decorator_with_kwargs(self):
-        from contracts import parse
+        from ...contracts import parse
 
         @new_contract
         def less_than(value, thresh=1):
@@ -300,7 +300,7 @@ class TestNewContract(unittest.TestCase):
         p.fail(2)
 
     def test_as_decorator_with_args_and_kwargs(self):
-        from contracts import parse
+        from ...contracts import parse
 
         @new_contract
         def less_than_all(value, a, b, c=1, d=5):

--- a/src/contracts/testing/test_particulars.py
+++ b/src/contracts/testing/test_particulars.py
@@ -1,7 +1,7 @@
-from contracts import parse
-from contracts.interface import Where, ContractSyntaxError
-from contracts.library import *  # @UnusedWildImport
-from contracts.syntax import ParseFatalException, ParseException
+from ...contracts import parse
+from ...contracts.interface import Where, ContractSyntaxError
+from ...contracts.library import *  # @UnusedWildImport
+from ...contracts.syntax import ParseFatalException, ParseException
 import unittest
 
 

--- a/src/contracts/testing/test_pickling.py
+++ b/src/contracts/testing/test_pickling.py
@@ -1,6 +1,6 @@
 from .utils import check_contracts_fail
-from contracts import ContractNotRespected, parse, Contract
-from contracts.test_registrar import (semantic_fail_examples,
+from ...contracts import ContractNotRespected, parse, Contract
+from ...contracts.test_registrar import (semantic_fail_examples,
     contract_fail_examples, good_examples)
 import pickle
 

--- a/src/contracts/testing/test_unicode_literals.py
+++ b/src/contracts/testing/test_unicode_literals.py
@@ -1,8 +1,8 @@
 # encoding: utf-8
 from __future__ import unicode_literals
 
-from contracts import contract
-from contracts.main import parse_contract_string
+from ...contracts import contract
+from ...contracts.main import parse_contract_string
 name = 'helló wörld from one'
 
 import unittest

--- a/src/contracts/useful_contracts/__init__.py
+++ b/src/contracts/useful_contracts/__init__.py
@@ -1,4 +1,4 @@
-from ..contracts import new_contract
+from Aspidites._vendor.contracts import new_contract
 
 try:
     import numpy

--- a/src/contracts/useful_contracts/__init__.py
+++ b/src/contracts/useful_contracts/__init__.py
@@ -1,4 +1,4 @@
-from contracts import new_contract
+from ..contracts import new_contract
 
 try:
     import numpy

--- a/src/contracts/useful_contracts/numbers.py
+++ b/src/contracts/useful_contracts/numbers.py
@@ -1,4 +1,4 @@
-from contracts.main import new_contract
+from ..contracts.main import new_contract
 
 __all__ = []
 

--- a/src/contracts/useful_contracts/numbers.py
+++ b/src/contracts/useful_contracts/numbers.py
@@ -1,18 +1,24 @@
-from ..contracts.main import new_contract
-
-__all__ = []
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
+from Aspidites._vendor.contracts.main import new_contract
+from math import isfinite
 
 try:
     import numpy  # @UnusedImport
 except ImportError:  # pragma: no cover
+    __all__ = ['finite']
     new_contract('float', 'Float')
     new_contract('int', 'Int')
-    new_contract('number', 'float|int')    
+    new_contract('number', 'float|int')
+
+    @new_contract
+    def finite(x):
+        return isfinite(x)
 else:
+    __all__ = []
     new_contract('float', 'Float|np_scalar_float|(np_scalar, array(float))')
     new_contract('int', 'Int|np_scalar_int|(np_scalar,array(int))')
     new_contract('uint', 'np_scalar_uint|(np_scalar, array(uint))')
     new_contract('number', 'float|int|uint')
 
-    
-    
+
+

--- a/src/contracts/useful_contracts/numpy_specific.pxd
+++ b/src/contracts/useful_contracts/numpy_specific.pxd
@@ -1,0 +1,4 @@
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+cimport numpy as np

--- a/src/contracts/useful_contracts/numpy_specific.py
+++ b/src/contracts/useful_contracts/numpy_specific.py
@@ -1,51 +1,53 @@
-from ..contracts import new_contract
+#cython: language_level=3, annotation_typing=True, c_string_encoding=utf-8, boundscheck=False, wraparound=False, initializedcheck=False
 import numpy as np
-from ..contracts.interface import describe_value, describe_type
-
+from Aspidites._vendor.contracts import new_contract
+from Aspidites._vendor.contracts.interface import describe_value, describe_type
 __all__ = ['finite']
+
 
 @new_contract
 def finite(x):
     return np.isfinite(x).all()
+
 
 new_contract('np_scalar_uint', 'np_uint8|np_uint16|np_uint32|np_uint64')
 new_contract('np_scalar_int', 'np_int8|np_int16|np_int32|np_int64')
 new_contract('np_scalar_float', 'np_float32|np_float64')
 new_contract('np_scalar_type', 'np_scalar_int|np_scalar_uint|np_scalar_float')
 
-@new_contract  
+
+@new_contract
 def np_zeroshape_array(x):
-#     scalars = [ 
-#     np.int,  # Platform integer (normally either int32 or int64)
-#     np.int8,  # Byte (-128 to 127)
-#     np.int16,  # Integer (-32768 to 32767)
-#     np.int32,  # Integer (-2147483648 to 2147483647)
-#     np.int64,  # Integer (9223372036854775808 to 9223372036854775807)
-#     np.uint8,  # Unsigned integer (0 to 255)
-#     np.uint16,  # Unsigned integer (0 to 65535)
-#     np.uint32,  # Unsigned integer (0 to 4294967295)
-#     np.uint64,  # Unsigned integer (0 to 18446744073709551615)
-#     np.float,  # Shorthand for float64.
-#     np.float16,  #  Half precision float: sign bit, 5 bits exponent, 10 bits mantissa
-#     np.float32,  #  Single precision float: sign bit, 8 bits exponent, 23 bits mantissa
-#     np.float64,  #  Double precision float: sign bit, 11 bits exponent, 52 bits mantissa
-#     np.complex,  #  Shorthand for complex128.
-#     np.complex64,  #    Complex number, represented by two 32-bit floats (real and imaginary components)
-#     np.complex128
-#     ]
-#  
-#     if isinstance(x, tuple(scalars)):
-#         return
-#  
-#  
+    scalars: tuple = (
+    np.ndarray,
+    np.int,  # Platform integer (normally either int32 or int64)
+    np.int8,  # Byte (-128 to 127)
+    np.int16,  # Integer (-32768 to 32767)
+    np.int32,  # Integer (-2147483648 to 2147483647)
+    np.int64,  # Integer (-9223372036854775808 to 9223372036854775807)
+    np.uint8,  # Unsigned integer (0 to 255)
+    np.uint16,  # Unsigned integer (0 to 65535)
+    np.uint32,  # Unsigned integer (0 to 4294967295)
+    np.uint64,  # Unsigned integer (0 to 18446744073709551615)
+    np.float,  # Shorthand for float64.
+    np.float16,  #  Half precision float: sign bit, 5 bits exponent, 10 bits mantissa
+    np.float32,  #  Single precision float: sign bit, 8 bits exponent, 23 bits mantissa
+    np.float64,  #  Double precision float: sign bit, 11 bits exponent, 52 bits mantissa
+    np.complex,  #  Shorthand for complex128.
+    np.complex64,  #    Complex number, represented by two 32-bit floats (real and imaginary components)
+    np.complex128
+    )
+
     if not isinstance(x, np.ndarray):
         msg = 'Not an array: %s %s ' % (type(x), describe_type(x))
         raise ValueError(msg)
- 
+
     if not x.shape == ():
         msg = 'Not a scalar: %s' % describe_value(x)
         raise ValueError(msg)
-     
+
+    return True
+
 
 new_contract('np_scalar', 'np_zeroshape_array|np_scalar_type')
 

--- a/src/contracts/useful_contracts/numpy_specific.py
+++ b/src/contracts/useful_contracts/numpy_specific.py
@@ -1,6 +1,6 @@
-from contracts import new_contract
+from ..contracts import new_contract
 import numpy as np
-from contracts.interface import describe_value, describe_type
+from ..contracts.interface import describe_value, describe_type
 
 __all__ = ['finite']
 

--- a/src/contracts/utils.py
+++ b/src/contracts/utils.py
@@ -107,7 +107,7 @@ def format_dict_long(d, informal=False):
 
 
 def _get_str(x, informal):
-    from contracts.interface import describe_value_multiline
+    from ..contracts.interface import describe_value_multiline
     if informal:
         s = x.__str__()
     else:

--- a/src/contracts/utils.py
+++ b/src/contracts/utils.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import traceback
 import warnings
 
-import six
+from ._compat import IS_PY3, unicode, basestring
 
 from .interface import describe_type, describe_value  # @UnusedImport # old interface
 
@@ -17,11 +16,11 @@ __all__ = [
 ]
 
 
-def indent(s, prefix, first=None):
-    if not isinstance(s, six.string_types):
+def indent(s, prefix, first=None): # pragma: no cover
+    if not isinstance(s, basestring):
         s = u'{}'.format(s)
 
-    assert isinstance(prefix, six.string_types)
+    assert isinstance(prefix, basestring)
     try:
         lines = s.split('\n')
     except UnicodeDecodeError:
@@ -45,7 +44,7 @@ def indent(s, prefix, first=None):
     return '\n'.join(res)
 
 
-def deprecated(func):
+def deprecated(func): # pragma: no cover
     """This is a decorator which can be used to mark functions
     as deprecated. It will result in a warning being emitted
     when the function is used."""
@@ -67,7 +66,7 @@ def check_isinstance(ob, expected, **kwargs):
         raise_type_mismatch(ob, expected, **kwargs)
 
 
-def raise_type_mismatch(ob, expected, **kwargs):
+def raise_type_mismatch(ob, expected, **kwargs): # pragma: no cover
     """ Raises an exception concerning ob having the wrong type. """
     e = 'Object not of expected type:'
     e += '\n  expected: {}'.format(expected)
@@ -76,7 +75,7 @@ def raise_type_mismatch(ob, expected, **kwargs):
     raise ValueError(e)
 
 
-def format_dict_long(d, informal=False):
+def format_dict_long(d, informal=False): # pragma: no cover
     """
         k: value
            kooked
@@ -106,7 +105,7 @@ def format_dict_long(d, informal=False):
     return res
 
 
-def _get_str(x, informal):
+def _get_str(x, informal):  # pragma: no cover
     from ..contracts.interface import describe_value_multiline
     if informal:
         s = x.__str__()
@@ -115,7 +114,7 @@ def _get_str(x, informal):
     return s
 
 
-def format_list_long(l, informal=False):
+def format_list_long(l, informal=False): # pragma: no cover
     """
         - My 
           first
@@ -131,7 +130,7 @@ def format_list_long(l, informal=False):
     return res
 
 
-def format_obs(d, informal=False):
+def format_obs(d, informal=False): # pragma: no cover
     """ Shows objects values and typed for the given dictionary """
     if not d:
         return d.__str__()
@@ -159,7 +158,7 @@ def format_obs(d, informal=False):
     return res
 
 
-def raise_wrapped(etype, e, msg, compact=False, **kwargs):
+def raise_wrapped(etype, e, msg, compact=False, **kwargs): # pragma: no cover
     """ Raises an exception of type etype by wrapping
         another exception "e" with its backtrace and adding
         the objects in kwargs as formatted by format_obs.
@@ -169,22 +168,24 @@ def raise_wrapped(etype, e, msg, compact=False, **kwargs):
         exc = output of sys.exc_info()
     """
 
-    if six.PY3:
-        from six import raise_from
-        msg += '\n' + indent(e, '| ')
+    if IS_PY3:
+        msg += '\n' + indent(e, '│ ')
         e2 = etype(_format_exc(msg, **kwargs))
         # e2 = raise_wrapped_make(etype, e, msg, compact=compact, **kwargs)
-        raise_from(e2, e)
+        try:
+            raise e2 from e
+        finally:
+            e2 = None
         # raise e2
     else:
         e2 = raise_wrapped_make(etype, e, msg, compact=compact, **kwargs)
         raise e2
 
 
-def raise_wrapped_make(etype, e, msg, compact=False, **kwargs):
+def raise_wrapped_make(etype, e, msg, compact=False, **kwargs): # pragma: no cover
     """ Constructs the exception to be thrown by raise_wrapped() """
     assert isinstance(e, BaseException), type(e)
-    check_isinstance(msg, six.text_type)
+    check_isinstance(msg, unicode)
     s = msg
     if kwargs:
         s += '\n' + format_obs(kwargs)
@@ -195,28 +196,29 @@ def raise_wrapped_make(etype, e, msg, compact=False, **kwargs):
     # else:
     if compact:
         es = e.__str__()
-    else:
+    else:  # pragma: no cover
         es = traceback.format_exc()  # only PY2
 
     s += '\n' + indent(es.strip(), '| ')
 
     return etype(s)
 
-def _format_exc(msg, **kwargs):
-    check_isinstance(msg, six.text_type)
+
+def _format_exc(msg, **kwargs): # pragma: no cover
+    check_isinstance(msg, unicode)
     s = msg
     if kwargs:
         s += '\n' + format_obs(kwargs)
     return s
 
 
-def raise_desc(etype, msg, args_first=False, **kwargs):
+def raise_desc(etype, msg, args_first=False, **kwargs):  # pragma: no cover
     """
     
         Example:
             raise_desc(ValueError, "I don't know", a=a, b=b)
     """
-    assert isinstance(msg, six.string_types), type(msg)
+    assert isinstance(msg, basestring), type(msg)
     s1 = msg
     if kwargs:
         s2 = format_obs(kwargs)
@@ -272,7 +274,7 @@ def raise_desc(etype, msg, args_first=False, **kwargs):
 
 # from decorator import decorator  # @UnresolvedImport
 
-def ignore_typeerror(f):
+def ignore_typeerror(f):  # pragma: no cover
     """ Recasts TypeError as Exception; otherwise pyparsing gets confused. """
 
     def f2(*args, **kwargs):


### PR DESCRIPTION
I noticed while vertically integrating some of your code locally in a project that I would get strange errors about changing contracts that had been previously defined. After much frustration I checked the imports and found that they were loading from my site-packages directory rather than the local src/ packages. This caused contracts to be defined by a mix of different versions from the local src/ directory and my site-packages. I have created this patch to remediate this issue. 

-Ross