### PR TITLE
Replace http by https in LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -7,7 +7,7 @@ version 3, as reproduced below.
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 


### PR DESCRIPTION
This is to fully match the official license wording at https://www.gnu.org/licenses/lgpl-3.0.txt