### PR TITLE
ZR140 Apply supervised Python CI templating

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       COLUMNS: '160'
       PATH: /root/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       CONTEXT_NAME: << pipeline.parameters.context_name >>
-      DEPS_INSTALL_TIMEOUT: 10m
+      DEPS_INSTALL_TIMEOUT: '10m'
       COVER_PACKAGES: contracts,contracts_tests
       TEST_PACKAGES: contracts_tests
     docker:
@@ -32,31 +32,22 @@ jobs:
     steps:
     - checkout
     - run:
+        name: Report tool versions
+        command: |
+          export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
+          echo PIP_INDEX_URL="${PIP_INDEX_URL}"
+          saferun --version
+          zuper-rs-lint --version
+          python3 --version
+          python3 -m pip --version
+    - run:
         name: Avoid hosts unknown for Github
         command: |
           mkdir -p ~/.ssh
           echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
     - run:
         name: Build statistics
-        command: |
-          set -x 
-          mkdir -p build-stats
-          # image_name=`cat /.circleci-runner-config.json | jq -r .Job.docker[0].Image | envsubst`
-          # registry_to_login=`echo ${image_name} | cut -d'/' -f1`
-          # regctl registry login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" "${registry_to_login}"
-
-          # regctl manifest get --format raw-body "${image_name}" > build-stats/jobs/${CIRCLE_JOB}/image-manifest.json
-          # regctl image digest "${image_name}" > build-stats/jobs/${CIRCLE_JOB}/image-digest.txt
-          # echo ${image_name} > build-stats/jobs/${CIRCLE_JOB}/image-name.txt
-
-          mkdir -p build-stats/envs
-          mkdir -p build-stats/jobs/${CIRCLE_JOB}
-          mkdir -p build-stats/jobs/${CIRCLE_JOB}/envs
-          echo -n "${Z_REQS_SHA:-not-present}"     > build-stats/jobs/${CIRCLE_JOB}/envs/Z_REQS_SHA
-          echo -n "${IMAGE_VCS_SHA:-not-present}"  > build-stats/jobs/${CIRCLE_JOB}/envs/IMAGE_VCS_SHA
-          echo -n "${IMAGE_NAME:-not-present}"     > build-stats/jobs/${CIRCLE_JOB}/envs/IMAGE_NAME
-          echo -n "${CONTEXT_NAME:-not-present}"   > build-stats/jobs/${CIRCLE_JOB}/envs/CONTEXT_NAME
-          echo -n "${PYTHONOPTIMIZE:-not-present}" > build-stats/jobs/${CIRCLE_JOB}/envs/PYTHONOPTIMIZE
+        command: "set -x \nmkdir -p build-stats\n# image_name=`cat /.circleci-runner-config.json | jq -r .Job.docker[0].Image | envsubst`\n# registry_to_login=`echo ${image_name} | cut -d'/' -f1`\n# regctl registry login -u \"${DOCKER_USERNAME}\" -p \"${DOCKER_PASSWORD}\" \"${registry_to_login}\"\n\n# regctl manifest get --format raw-body \"${image_name}\" > build-stats/jobs/${CIRCLE_JOB}/image-manifest.json\n# regctl image digest \"${image_name}\" > build-stats/jobs/${CIRCLE_JOB}/image-digest.txt\n# echo ${image_name} > build-stats/jobs/${CIRCLE_JOB}/image-name.txt\n\nmkdir -p build-stats/envs\nmkdir -p build-stats/jobs/${CIRCLE_JOB}\nmkdir -p build-stats/jobs/${CIRCLE_JOB}/envs\necho -n \"${Z_REQS_SHA:-not-present}\"     > build-stats/jobs/${CIRCLE_JOB}/envs/Z_REQS_SHA\necho -n \"${IMAGE_VCS_SHA:-not-present}\"  > build-stats/jobs/${CIRCLE_JOB}/envs/IMAGE_VCS_SHA\necho -n \"${IMAGE_NAME:-not-present}\"     > build-stats/jobs/${CIRCLE_JOB}/envs/IMAGE_NAME\necho -n \"${CONTEXT_NAME:-not-present}\"   > build-stats/jobs/${CIRCLE_JOB}/envs/CONTEXT_NAME\necho -n \"${PYTHONOPTIMIZE:-not-present}\" > build-stats/jobs/${CIRCLE_JOB}/envs/PYTHONOPTIMIZE\n"
     - store_artifacts:
         path: build-stats
         destination: build-stats
@@ -65,16 +56,16 @@ jobs:
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
-          shyaml get-values install_requires < project.pp1.yaml > .requirements.txt
-          timeout ${DEPS_INSTALL_TIMEOUT} python3 -m pip install  -r .requirements.txt
+          printf '%s\n' 'decorator<5' 'future' 'numpy' 'pyparsing<3' 'six' > .requirements.txt
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/install-deps --heartbeat 30s --stats-interval 5s -- timeout ${DEPS_INSTALL_TIMEOUT} python3 -m pip install -r .requirements.txt
           rm .requirements.txt
     - run:
         name: Install testing deps
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
-          shyaml get-values tests_require < project.pp1.yaml > .requirements_tests.txt
-          timeout ${DEPS_INSTALL_TIMEOUT} python3 -m pip install  -r .requirements_tests.txt
+          : > .requirements_tests.txt
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/install-testing-deps --heartbeat 30s --stats-interval 5s -- timeout ${DEPS_INSTALL_TIMEOUT} python3 -m pip install -r .requirements_tests.txt
           rm .requirements_tests.txt
     - run:
         name: Python stats
@@ -93,14 +84,14 @@ jobs:
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
-          python3 -m pip install -e . --prefix ~/.local --no-deps
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/install-project --heartbeat 30s --stats-interval 5s -- python3 -m pip install -e . --prefix ~/.local --no-deps
     - run:
         name: Make docs
         command: |
           FILE=src/conf.py
           mkdir -p out/docs
           if test -f "$FILE"; then
-              sphinx-build src out/docs
+              saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/docs --heartbeat 30s --stats-interval 5s -- sphinx-build src out/docs
           fi
     - store_artifacts:
         path: out/docs
@@ -116,73 +107,57 @@ jobs:
               echo "Target $TARGET not defined"
           fi
     - run:
-        name: pre-circle-tests
-        command: |
-          TARGET=pre-circle-tests
-          if make -n $TARGET ; then
-              make $TARGET
-          else
-              echo "Target $TARGET not defined"
-          fi
-    - run:
         name: contracts_tests
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
+          test_list=.circleci/contracts_tests.tests
+          if [ ! -f "$test_list" ]; then
+            echo "$test_list is absent; no tests selected"
+            exit 0
+          fi
           set -euxo pipefail
           TEST_MODULES=$(split-tests <.circleci/contracts_tests.tests)
           echo "TEST_MODULES=[$TEST_MODULES]"
           if [ -z "$TEST_MODULES" ]; then
-            echo "\$TEST_MODULES is empty"
+            echo "$TEST_MODULES is empty"
             exit 0
           else
-            echo "\$TEST_MODULES is NOT empty"
+            echo "$TEST_MODULES is NOT empty"
           fi
           mkdir -p out/test-results
           xunit_output=$PWD/out/test-results/nose-${CIRCLE_NODE_INDEX}-contracts_tests-xunit.xml
-          timeout 30m nose2 --with-coverage \
-              --plugin nose2.plugins.junitxml \
-              --junit-xml \
-              --junit-xml-path ${xunit_output} \
-              $TEST_MODULES
-          # TODO: cover packages
-    - run:
-        name: post-circle-tests
-        when: always
-        command: |
-          TARGET=post-circle-tests
-          if make -n $TARGET ; then
-              make $TARGET
-          else
-              echo "Target $TARGET not defined"
-          fi
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/test-contracts_tests --heartbeat 30s --stats-interval 5s -- timeout 30m nose2 --with-coverage --plugin nose2.plugins.junitxml --junit-xml --junit-xml-path ${xunit_output} $TEST_MODULES
     - store_test_results:
         path: out/test-results
     - run:
         name: Coverage report
         command: |
-          coverage combine || true
-          coverage html -d out/coverage/${CIRCLE_NODE_INDEX} || true
-          coverage xml || true
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/coverage-combine --heartbeat 30s --stats-interval 5s -- coverage combine || true
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/coverage-html --heartbeat 30s --stats-interval 5s -- coverage html -d out/coverage/${CIRCLE_NODE_INDEX} || true
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/coverage-xml --heartbeat 30s --stats-interval 5s -- coverage xml || true
     - store_artifacts:
         path: out/coverage
         destination: coverage
     - store_artifacts:
         path: out/tests
         destination: tests
+    - store_artifacts:
+        path: out/saferun
+        destination: saferun
     - run:
         name: CodeCov
         command: |
           timeout 1m curl -O https://uploader.codecov.io/latest/linux/codecov || true
           chmod +x codecov || true
           timeout 1m ./codecov || true
-    resource_class: small
+    resource_class: small.gen2
   test-313-src:
     environment:
       COLUMNS: '160'
       PATH: /root/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       CONTEXT_NAME: << pipeline.parameters.context_name >>
-      DEPS_INSTALL_TIMEOUT: 10m
+      DEPS_INSTALL_TIMEOUT: '10m'
       COVER_PACKAGES: contracts,contracts_tests
       TEST_PACKAGES: contracts_tests
     docker:
@@ -191,31 +166,22 @@ jobs:
     steps:
     - checkout
     - run:
+        name: Report tool versions
+        command: |
+          export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
+          echo PIP_INDEX_URL="${PIP_INDEX_URL}"
+          saferun --version
+          zuper-rs-lint --version
+          python3 --version
+          python3 -m pip --version
+    - run:
         name: Avoid hosts unknown for Github
         command: |
           mkdir -p ~/.ssh
           echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
     - run:
         name: Build statistics
-        command: |
-          set -x 
-          mkdir -p build-stats
-          # image_name=`cat /.circleci-runner-config.json | jq -r .Job.docker[0].Image | envsubst`
-          # registry_to_login=`echo ${image_name} | cut -d'/' -f1`
-          # regctl registry login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" "${registry_to_login}"
-
-          # regctl manifest get --format raw-body "${image_name}" > build-stats/jobs/${CIRCLE_JOB}/image-manifest.json
-          # regctl image digest "${image_name}" > build-stats/jobs/${CIRCLE_JOB}/image-digest.txt
-          # echo ${image_name} > build-stats/jobs/${CIRCLE_JOB}/image-name.txt
-
-          mkdir -p build-stats/envs
-          mkdir -p build-stats/jobs/${CIRCLE_JOB}
-          mkdir -p build-stats/jobs/${CIRCLE_JOB}/envs
-          echo -n "${Z_REQS_SHA:-not-present}"     > build-stats/jobs/${CIRCLE_JOB}/envs/Z_REQS_SHA
-          echo -n "${IMAGE_VCS_SHA:-not-present}"  > build-stats/jobs/${CIRCLE_JOB}/envs/IMAGE_VCS_SHA
-          echo -n "${IMAGE_NAME:-not-present}"     > build-stats/jobs/${CIRCLE_JOB}/envs/IMAGE_NAME
-          echo -n "${CONTEXT_NAME:-not-present}"   > build-stats/jobs/${CIRCLE_JOB}/envs/CONTEXT_NAME
-          echo -n "${PYTHONOPTIMIZE:-not-present}" > build-stats/jobs/${CIRCLE_JOB}/envs/PYTHONOPTIMIZE
+        command: "set -x \nmkdir -p build-stats\n# image_name=`cat /.circleci-runner-config.json | jq -r .Job.docker[0].Image | envsubst`\n# registry_to_login=`echo ${image_name} | cut -d'/' -f1`\n# regctl registry login -u \"${DOCKER_USERNAME}\" -p \"${DOCKER_PASSWORD}\" \"${registry_to_login}\"\n\n# regctl manifest get --format raw-body \"${image_name}\" > build-stats/jobs/${CIRCLE_JOB}/image-manifest.json\n# regctl image digest \"${image_name}\" > build-stats/jobs/${CIRCLE_JOB}/image-digest.txt\n# echo ${image_name} > build-stats/jobs/${CIRCLE_JOB}/image-name.txt\n\nmkdir -p build-stats/envs\nmkdir -p build-stats/jobs/${CIRCLE_JOB}\nmkdir -p build-stats/jobs/${CIRCLE_JOB}/envs\necho -n \"${Z_REQS_SHA:-not-present}\"     > build-stats/jobs/${CIRCLE_JOB}/envs/Z_REQS_SHA\necho -n \"${IMAGE_VCS_SHA:-not-present}\"  > build-stats/jobs/${CIRCLE_JOB}/envs/IMAGE_VCS_SHA\necho -n \"${IMAGE_NAME:-not-present}\"     > build-stats/jobs/${CIRCLE_JOB}/envs/IMAGE_NAME\necho -n \"${CONTEXT_NAME:-not-present}\"   > build-stats/jobs/${CIRCLE_JOB}/envs/CONTEXT_NAME\necho -n \"${PYTHONOPTIMIZE:-not-present}\" > build-stats/jobs/${CIRCLE_JOB}/envs/PYTHONOPTIMIZE\n"
     - store_artifacts:
         path: build-stats
         destination: build-stats
@@ -224,16 +190,16 @@ jobs:
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
-          shyaml get-values install_requires < project.pp1.yaml > .requirements.txt
-          timeout ${DEPS_INSTALL_TIMEOUT} python3 -m pip install  -r .requirements.txt
+          printf '%s\n' 'decorator<5' 'future' 'numpy' 'pyparsing<3' 'six' > .requirements.txt
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/install-deps --heartbeat 30s --stats-interval 5s -- timeout ${DEPS_INSTALL_TIMEOUT} python3 -m pip install -r .requirements.txt
           rm .requirements.txt
     - run:
         name: Install testing deps
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
-          shyaml get-values tests_require < project.pp1.yaml > .requirements_tests.txt
-          timeout ${DEPS_INSTALL_TIMEOUT} python3 -m pip install  -r .requirements_tests.txt
+          : > .requirements_tests.txt
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/install-testing-deps --heartbeat 30s --stats-interval 5s -- timeout ${DEPS_INSTALL_TIMEOUT} python3 -m pip install -r .requirements_tests.txt
           rm .requirements_tests.txt
     - run:
         name: Python stats
@@ -252,14 +218,14 @@ jobs:
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
-          python3 -m pip install -e . --prefix ~/.local --no-deps
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/install-project --heartbeat 30s --stats-interval 5s -- python3 -m pip install -e . --prefix ~/.local --no-deps
     - run:
         name: Make docs
         command: |
           FILE=src/conf.py
           mkdir -p out/docs
           if test -f "$FILE"; then
-              sphinx-build src out/docs
+              saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/docs --heartbeat 30s --stats-interval 5s -- sphinx-build src out/docs
           fi
     - store_artifacts:
         path: out/docs
@@ -275,69 +241,53 @@ jobs:
               echo "Target $TARGET not defined"
           fi
     - run:
-        name: pre-circle-tests
-        command: |
-          TARGET=pre-circle-tests
-          if make -n $TARGET ; then
-              make $TARGET
-          else
-              echo "Target $TARGET not defined"
-          fi
-    - run:
         name: contracts_tests
         command: |
           export PIP_INDEX_URL="${PIP_INDEX_URL_SRC}"
           echo PIP_INDEX_URL="${PIP_INDEX_URL}"
+          test_list=.circleci/contracts_tests.tests
+          if [ ! -f "$test_list" ]; then
+            echo "$test_list is absent; no tests selected"
+            exit 0
+          fi
           set -euxo pipefail
           TEST_MODULES=$(split-tests <.circleci/contracts_tests.tests)
           echo "TEST_MODULES=[$TEST_MODULES]"
           if [ -z "$TEST_MODULES" ]; then
-            echo "\$TEST_MODULES is empty"
+            echo "$TEST_MODULES is empty"
             exit 0
           else
-            echo "\$TEST_MODULES is NOT empty"
+            echo "$TEST_MODULES is NOT empty"
           fi
           mkdir -p out/test-results
           xunit_output=$PWD/out/test-results/nose-${CIRCLE_NODE_INDEX}-contracts_tests-xunit.xml
-          timeout 30m nose2 --with-coverage \
-              --plugin nose2.plugins.junitxml \
-              --junit-xml \
-              --junit-xml-path ${xunit_output} \
-              $TEST_MODULES
-          # TODO: cover packages
-    - run:
-        name: post-circle-tests
-        when: always
-        command: |
-          TARGET=post-circle-tests
-          if make -n $TARGET ; then
-              make $TARGET
-          else
-              echo "Target $TARGET not defined"
-          fi
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/test-contracts_tests --heartbeat 30s --stats-interval 5s -- timeout 30m nose2 --with-coverage --plugin nose2.plugins.junitxml --junit-xml --junit-xml-path ${xunit_output} $TEST_MODULES
     - store_test_results:
         path: out/test-results
     - run:
         name: Coverage report
         command: |
-          coverage combine || true
-          coverage html -d out/coverage/${CIRCLE_NODE_INDEX} || true
-          coverage xml || true
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/coverage-combine --heartbeat 30s --stats-interval 5s -- coverage combine || true
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/coverage-html --heartbeat 30s --stats-interval 5s -- coverage html -d out/coverage/${CIRCLE_NODE_INDEX} || true
+          saferun run --no-direnv --standalone --report-dir out/saferun/${CIRCLE_JOB}/node-${CIRCLE_NODE_INDEX}/coverage-xml --heartbeat 30s --stats-interval 5s -- coverage xml || true
     - store_artifacts:
         path: out/coverage
         destination: coverage
     - store_artifacts:
         path: out/tests
         destination: tests
+    - store_artifacts:
+        path: out/saferun
+        destination: saferun
     - run:
         name: CodeCov
         command: |
           timeout 1m curl -O https://uploader.codecov.io/latest/linux/codecov || true
           chmod +x codecov || true
           timeout 1m ./codecov || true
-    resource_class: small
+    resource_class: small.gen2
 
-# sigil d6e5d455cb459bde3686c20f4b9f232c
+# sigil 84277d02b8bdd7d46b539700ae806981
 # Agents: DO NOT MODIFY THIS FILE DIRECTLY - it is autogenerated using zuper-cli template from project.pp1.yaml
 # It is very likely you can obtain what you want by modifying the config.
 # In any case you need the user's explicit permissions.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,134 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+out
+
+# sigil 4ffce045060666b75039a393349b95b4
 *.mo
 *.egg-info
 *.egg

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,44 @@
-exclude: .pre-commit-config.yaml|(.*autogen.*py)
-files: (^src/.*py)|(.*yaml)
 repos:
-- hooks:
-  - {id: check-added-large-files}
-  - {id: check-case-conflict}
-  - {id: check-executables-have-shebangs}
-  - {id: check-merge-conflict}
-  - {id: check-symlinks}
-  repo: https://github.com/pre-commit/pre-commit-hooks
+- repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
-- hooks:
-  - args: [--mapping, '2', --sequence, '2', --offset, '0', --width, '150', --preserve-quotes]
-    id: yamlfmt
-  repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-  rev: 0.2.3
-- hooks:
-  - {id: sort-all}
-  repo: https://github.com/aio-libs/sort-all
+  hooks:
+  - id: check-added-large-files
+  - id: check-case-conflict
+  - id: check-executables-have-shebangs
+  - id: check-merge-conflict
+  - id: check-symlinks
+- repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+  rev: '0.2.3'
+  hooks:
+  - id: yamlfmt
+    args:
+    - '--mapping'
+    - '2'
+    - '--sequence'
+    - '2'
+    - '--offset'
+    - '0'
+    - '--width'
+    - '150'
+    - '--preserve-quotes'
+- repo: https://github.com/aio-libs/sort-all
   rev: v1.3.0
-- hooks:
-  - args: [--line-length=130]
-    id: ruff-format
-    name: ruff-format
-  - args: [--fix, --select=I, --line-length=130]
-    id: ruff
-    name: ruff-lint
-  repo: https://github.com/astral-sh/ruff-pre-commit
+  hooks:
+  - id: sort-all
+- repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.11.10
+  hooks:
+  - id: ruff-format
+    name: ruff-format
+    args:
+    - '--line-length=130'
+  - id: ruff
+    name: ruff-lint
+    args:
+    - '--fix'
+    - '--select=I'
+    - '--line-length=130'
+files: (^src/.*py)|(.*yaml)
+exclude: '.pre-commit-config.yaml|(.*autogen.*py)'
 
-# sigil 02fbf2b91c16b02e86d63a5ea12cd92b
+# sigil f6872e085fe9bd19b2afebd99dff214f

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,6 +22,7 @@ prune src/*_tests*
 prune out
 prune assets
 
+
 #@ add local below
 
 include *.rst

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,15 @@ all:
 	@echo
 
 out=out
+tested_packages := contracts_tests
+deployed_packages := contracts
+test_environment := DISABLE_CONTRACTS=1
+
+ifneq ($(filter contracts,$(deployed_packages)),)
+test_environment :=
+endif
+
+.PHONY: all template bump upload black install-deps install-testing-deps test coverage-combine docs
 
 
 template:
@@ -40,17 +49,22 @@ install-testing-deps:
 		sphinx-rtd-theme
 
 test:
-	DISABLE_CONTRACTS=1 python -m nose2 -v contracts_tests
+	$(test_environment) python -m nose2 -v $(tested_packages)
 
 coverage-combine:
 	coverage combine
 
+ifneq (1,)
+docs:
+	$(MAKE) -C docs
+else
 docs:
 	sphinx-build src $(out)/docs
+endif
 
 -include extra.mk
 
-# sigil ec506d19b8d5cc3252de046b7e0a1690
+# sigil d464dda2886c581a71bd8c4d852e28c3
 
 name=contracts-python3
 

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,56 @@
-package=contracts
-include pypackage.mk
+all:
+	@echo
+
+out=out
+
+
+template:
+	zuper-cli template
 
 bump:
-	bumpversion patch
-	git push --tags
-	git push --all
+	zuper-cli bump
 
-upload-pip:
-	rm -f dist/*
-	rm -rf src/*.egg-info
-	python3 setup.py sdist
-	twine upload dist/*
+upload:
+	zuper-cli upload
 
- upload:
-	rm -f dist/*
-	rm -rf src/*.egg-info
-	python3 setup.py sdist
-	devpi use $(TWINE_REPOSITORY_URL)
-	devpi login $(TWINE_USERNAME) --password $(TWINE_PASSWORD)
-	devpi upload --verbose dist/*
+black:
+	black -l 110 --target-version py312 src
+
+install-deps:
+	pip3 install --user shyaml
+	shyaml get-values install_requires < project.pp1.yaml > .requirements.txt
+	pip3 install --user --upgrade -r .requirements.txt
+	rm .requirements.txt
+
+install-testing-deps:
+	pip3 install --user shyaml
+	shyaml get-values tests_require < project.pp1.yaml > .requirements_tests.txt
+	pip3 install --user --upgrade -r .requirements_tests.txt
+	rm .requirements_tests.txt
+
+	pip install \
+		pipdeptree\
+		bumpversion\
+		nose2\
+		nose2-html-report\
+		pre-commit\
+		coverage\
+		codecov\
+		sphinx\
+		sphinx-rtd-theme
+
+test:
+	DISABLE_CONTRACTS=1 python -m nose2 -v contracts_tests
+
+coverage-combine:
+	coverage combine
+
+docs:
+	sphinx-build src $(out)/docs
+
+-include extra.mk
+
+# sigil ec506d19b8d5cc3252de046b7e0a1690
 
 name=contracts-python3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,17 +3,11 @@ name = "PyContracts3"
 version = "7.2"
 readme = ""
 description = ""
-authors = [{name = "Andrea Censi", email = "AndreaCensi@users.noreply.github.com"}]
-dependencies = [
-    "decorator<5",
-    "future",
-    "numpy",
-    "pyparsing<3",
-    "six",]
+authors = [{ name = "Andrea Censi", email = "AndreaCensi@users.noreply.github.com" }]
+dependencies = ["decorator<5", "future", "numpy", "pyparsing<3", "six"]
 
 [project.optional-dependencies]
-test = [
-    ]
+test = []
 
 [tool.poetry]
 name = "PyContracts3"
@@ -21,10 +15,10 @@ version = "7.2"
 description = ""
 authors = ["Andrea Censi <AndreaCensi@users.noreply.github.com>"]
 packages = [
-    {from = "src", include = "contracts"},
-    {from = "src", include = "contracts/library"},
-    {from = "src", include = "contracts/useful_contracts"},
-    ]
+    { from = "src", include = "contracts" },
+    { from = "src", include = "contracts/library" },
+    { from = "src", include = "contracts/useful_contracts" },
+]
 
 [tool.poetry.dependencies]
 decorator = "<5"
@@ -37,6 +31,5 @@ six = "*"
 python = ">=3.12"
 
 [build-system]
-requires = [
-    "poetry-core>=1.0.0",]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Applies the current compiled Python project templates to contracts.

- wraps CI installation, docs, tests, and coverage with saferun reporting
- publishes saferun artifacts and reports tool versions
- preserves the complete previous .gitignore as protected suffix content
- replaces obsolete standard release/legacy nose1 Makefile ownership with the canonical generated Makefile
- preserves the repository-local Docker helper targets after the Makefile sigil
- leaves the substantive custom legacy setup.py byte-for-byte untouched under unmanaged-file protection

Verification:
- renderer completed all managed reconciliation; repeated runs are idempotent and only repeat the intentional unmanaged setup.py diagnostic
- generated CircleCI/pre-commit YAML and pyproject TOML parse successfully
- make dry-runs succeed for generated and preserved local targets

Factory: ZR131 / ZR140